### PR TITLE
Fix circular buffer fullness tracking

### DIFF
--- a/Sources/SwiftTUI/ViewBuffer.swift
+++ b/Sources/SwiftTUI/ViewBuffer.swift
@@ -34,19 +34,19 @@ public struct CircularBuffer<T>  {
     }
 
     public mutating func put(_ element: T) {
-      
+
+      if isFull {                    // buffer is full and now overwriting its own ass
+        tail = (tail + 1) % capacity // discard old values...
+      } else {
+        filled = min(filled + 1, capacity)
+      }
+
       elements[head] = element
       head = (head + 1) % capacity
-      
-      if head == tail {              // buffer is full and now overwriting its own ass
-        tail = (tail + 1) % capacity // if we cared about that, we should bounce this
-      }                              // but I actually want it to discard old values...
-      
-      filled = min((filled + 1),  capacity)
     }
 
     // ...so instead we'll put a check, for completeness sake.
-    public var isFull : Bool { return head == tail }
+    public var isFull : Bool { return filled == capacity }
 
 
 
@@ -55,7 +55,9 @@ public struct CircularBuffer<T>  {
 
     public mutating func get() -> T {
       defer {
+        elements[tail] = nil
         tail = (tail + 1) % capacity
+        filled = max(filled - 1, 0)
       }
       return elements[tail]! // NB this here is fatal, your pointers are wrong.
     }

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -1,3 +1,58 @@
 import XCTest
 @testable import SwiftTUI
 
+final class CircularBufferTests: XCTestCase {
+
+    func testCircularBufferFullnessTransitions() {
+        var buffer = CircularBuffer<Int>(capacity: 3)
+
+        XCTAssertEqual(buffer.filled, 0)
+        XCTAssertFalse(buffer.isFull)
+
+        buffer.put(1)
+        XCTAssertEqual(buffer.filled, 1)
+        XCTAssertFalse(buffer.isFull)
+
+        buffer.put(2)
+        XCTAssertEqual(buffer.filled, 2)
+        XCTAssertFalse(buffer.isFull)
+
+        buffer.put(3)
+        XCTAssertEqual(buffer.filled, 3)
+        XCTAssertTrue(buffer.isFull)
+
+        _ = buffer.get()
+        XCTAssertEqual(buffer.filled, 2)
+        XCTAssertFalse(buffer.isFull)
+
+        buffer.put(4)
+        XCTAssertEqual(buffer.filled, 3)
+        XCTAssertTrue(buffer.isFull)
+
+        _ = buffer.get()
+        XCTAssertEqual(buffer.filled, 2)
+        XCTAssertFalse(buffer.isFull)
+
+        _ = buffer.get()
+        XCTAssertEqual(buffer.filled, 1)
+        XCTAssertFalse(buffer.isFull)
+
+        _ = buffer.get()
+        XCTAssertEqual(buffer.filled, 0)
+        XCTAssertFalse(buffer.isFull)
+
+        buffer.put(5)
+        buffer.put(6)
+        buffer.put(7)
+        XCTAssertTrue(buffer.isFull)
+
+        buffer.put(8)
+        XCTAssertTrue(buffer.isFull)
+        XCTAssertEqual(buffer.filled, 3)
+
+        _ = buffer.get()
+        XCTAssertEqual(buffer.filled, 2)
+        XCTAssertFalse(buffer.isFull)
+    }
+}
+


### PR DESCRIPTION
## Summary
- align circular buffer fullness detection with tracked element count and keep the count in sync when pushing and popping
- clear removed slots and update the count on get so empty buffers are not reported as full
- add unit coverage that fills, drains, and wraps the buffer to confirm isFull only toggles when appropriate

## Testing
- swift test *(fails: unable to clone dependencies due to network 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d81869ad3c8328acf4ac86c156a239