### PR TITLE
Clamp scroll offset to zero and extend tests

### DIFF
--- a/Sources/SwiftTUI/ViewBuffer.swift
+++ b/Sources/SwiftTUI/ViewBuffer.swift
@@ -148,7 +148,8 @@ public struct LineBuffer {
   // we need to be checking the spans here, or in the calling code
   public mutating func scrollUp (span: Int, _ count : Int = 1) {
     let maxoffset = (buffer.filled + 1) - span
-    offset = min(offset + count, maxoffset)
+    // The scroll offset cannot exceed the number of lines available nor dip below zero.
+    offset = min(offset + count, max(0, maxoffset))
   }
   public mutating func scrollDown ( _ count: Int = 1) {
     offset = max(0, offset - count)

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -56,3 +56,24 @@ final class CircularBufferTests: XCTestCase {
     }
 }
 
+final class LineBufferScrollTests: XCTestCase {
+
+    func testScrollUpClampsWithinAvailableHistory() {
+        var buffer = LineBuffer(capacity: 8, breakchar: "\n")
+        buffer.push(chars: "one\ntwo\nthree\nfour\n")
+
+        buffer.scrollUp(span: 2, 10)
+
+        XCTAssertEqual(buffer.offset, 3)
+    }
+
+    func testScrollUpClampsToZeroWhenSpanExceedsHistory() {
+        var buffer = LineBuffer(capacity: 4, breakchar: "\n")
+        buffer.push(chars: "one\ntwo\n")
+
+        buffer.scrollUp(span: 5, 3)
+
+        XCTAssertEqual(buffer.offset, 0)
+    }
+}
+


### PR DESCRIPTION
## Summary
- clamp the scroll offset to remain within the available history range and document the constraint
- add tests that verify upward scrolling is bounded and that large spans do not produce negative offsets

## Testing
- swift test *(fails: dependency fetch requires network access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d81a7292a88328965d7e345edcb615