### PR TITLE
Handle nil entries in line buffer fetch

### DIFF
--- a/Sources/SwiftTUI/ViewBuffer.swift
+++ b/Sources/SwiftTUI/ViewBuffer.swift
@@ -166,11 +166,19 @@ public struct LineBuffer {
     log("spantop \(spantop)")
     
     for i in 0..<(span) {
-      
+
       let pos = (spantop + i) %% buffer.capacity
-      
+
       if pos == buffer.head { lines.append( currentline )   }
-      else                  { lines.append( String(buffer[ pos ]!.dropLast())) }  // still got an explodey nil
+      else {
+        if let stored = buffer[pos] {
+          var line = stored
+          if line.last == breakchar { line.removeLast() }
+          lines.append(line)
+        } else {
+          lines.append("")
+        }
+      }
     }                       // NB the last char on all non curremt lines == newline
                             //    which will scroll when we hit the bottom, bad.
     return lines

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -58,6 +58,23 @@ final class CircularBufferTests: XCTestCase {
 
 final class LineBufferScrollTests: XCTestCase {
 
+    func testFetchSpanImmediatelyAfterInitializationReturnsEmptyLines() {
+        var buffer = LineBuffer(capacity: 4, breakchar: "\n")
+
+        let lines = buffer.fetch(span: 2)
+
+        XCTAssertEqual(lines, ["", ""])
+    }
+
+    func testFetchTrimsTrailingBreakCharactersOnCompletedLines() {
+        var buffer = LineBuffer(capacity: 4, breakchar: "\n")
+        buffer.push(chars: "line1\nline2\npartial")
+
+        let lines = buffer.fetch(span: 3)
+
+        XCTAssertEqual(lines, ["line1", "line2", "partial"])
+    }
+
     func testScrollUpClampsWithinAvailableHistory() {
         var buffer = LineBuffer(capacity: 8, breakchar: "\n")
         buffer.push(chars: "one\ntwo\nthree\nfour\n")


### PR DESCRIPTION
## Summary
- handle nil circular buffer entries when fetching lines and trim trailing break characters only when present
- add unit tests covering fetch right after initialization and completed line trimming

## Testing
- `swift test` *(fails: unable to clone dependencies due to 403 while fetching remote packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d81b2cdc308328be924a6b5a08b9dc