### PR TITLE
Add README example for menu bar and status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # SwiftTUI
 
-A description of this package.
+SwiftTUI lets you compose terminal user interfaces in idiomatic Swift.
+
+## Menu Bar Example
+
+The snippet below demonstrates how you can set up a simple menu bar with a
+couple of actions and a status bar message.
+
+```swift
+import SwiftTUI
+
+@main
+struct DemoApp {
+    static func main() {
+        let app = Application {
+            MenuBar {
+                Menu("File") {
+                    Action("New Window") {
+                        print("Create a new window")
+                    }
+                    Action("Close Window") {
+                        print("Close the current window")
+                    }
+                }
+
+                Menu("Help") {
+                    Action("About SwiftTUI") {
+                        print("Show about dialog")
+                    }
+                }
+            }
+
+            StatusBar(text: "ncurses can suck it - In the BAYOU. OUTLAW COUNTRY!")
+        }
+
+        app.run()
+    }
+}
+```
+
+The `MenuBar` composes menus and actions, and the `StatusBar` ensures the
+message "ncurses can suck it - In the BAYOU. OUTLAW COUNTRY!" is always visible
+at the bottom of the terminal.


### PR DESCRIPTION
## Summary
- update the README with a menu bar example showing basic actions
- document how to add a status bar message

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d82d3c560483288993bc9535b9c07b