### PR TITLE
Add Linux stubs and conditional imports for SwiftTUI build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SwiftTUI",
-            dependencies: ["Trace", "PosixInputStream", "SerialPort"]),
+            dependencies: [
+                .product(name: "Trace", package: "Trace", condition: .when(platforms: [.macOS])),
+                .product(name: "PosixInputStream", package: "PosixInputStream", condition: .when(platforms: [.macOS])),
+                .product(name: "SerialPort", package: "SerialPort", condition: .when(platforms: [.macOS]))
+            ]),
         .testTarget(
             name: "SwiftTUITests",
             dependencies: ["SwiftTUI"]),

--- a/Sources/SwiftTUI/LinuxSupport.swift
+++ b/Sources/SwiftTUI/LinuxSupport.swift
@@ -1,0 +1,27 @@
+#if os(Linux)
+import Foundation
+
+public struct Trace: Error, CustomStringConvertible {
+  public let origin: Any
+  public let tag: String
+
+  public init(_ origin: Any, tag: String) {
+    self.origin = origin
+    self.tag = tag
+  }
+
+  public var description: String {
+    "Trace(origin: \(String(describing: origin)), tag: \(tag))"
+  }
+}
+
+public final class PosixInputStream {
+  public typealias Handler = (Result<Data, Trace>) -> Void
+
+  public var handler: Handler?
+
+  public init(descriptor: Int32) {
+    _ = descriptor
+  }
+}
+#endif

--- a/Sources/SwiftTUI/OutputController.swift
+++ b/Sources/SwiftTUI/OutputController.swift
@@ -2,10 +2,12 @@
 import Foundation
 
 public struct OutputController {
-  
+
+  public init() {}
+
   // use to send ANSI sequences to e.g get responses
-  
-  func send(_ ansi: AnsiSequence...) {
+
+  public func send(_ ansi: AnsiSequence...) {
     DispatchQueue.main.async {
       print ( ansi.map { $0.description }.joined(separator: ""), terminator: "" )
     }
@@ -15,7 +17,7 @@ public struct OutputController {
   // use to send text that should be displayed, to incude ANSI sequences.
   // this one tracks the cursor position
   
-  func display(_ ansi: AnsiSequence...) {
+  public func display(_ ansi: AnsiSequence...) {
     DispatchQueue.main.async { [self] in
       print( ansi.map { $0.description }.joined(separator: ""), terminator: "" )
       send( .cursorPosition )

--- a/Sources/SwiftTUI/SwiftTUI.swift
+++ b/Sources/SwiftTUI/SwiftTUI.swift
@@ -1,7 +1,13 @@
 import Foundation
+#if canImport(OSLog)
 import OSLog
+#endif
 
 public func log(_ string: String) {
+#if canImport(OSLog)
   os_log(.debug, "%{public}s", "\(string)")
+#else
+  print(string)
+#endif
 }
 

--- a/Sources/SwiftTUI/TerminalInput.swift
+++ b/Sources/SwiftTUI/TerminalInput.swift
@@ -1,7 +1,9 @@
 
 
 import Foundation
+#if canImport(Trace)
 import Trace
+#endif
 
 /*
   Handle the various things that the macOS (and this is NOT portable)

--- a/Sources/SwiftTUI/TerminalInputController.swift
+++ b/Sources/SwiftTUI/TerminalInputController.swift
@@ -1,8 +1,17 @@
 
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
+#if canImport(Trace)
 import Trace
+#endif
+#if canImport(PosixInputStream)
 import PosixInputStream
+#endif
 
 public class TerminalInputController {
   

--- a/Sources/SwiftTUI/TerminalPresenter.swift
+++ b/Sources/SwiftTUI/TerminalPresenter.swift
@@ -120,7 +120,7 @@ public final class TerminalPresenter {
 
       awaitingAltChord = false
       guard let byte = data.dropFirst().first else { return }
-      guard let scalar = UnicodeScalar(byte) else { return }
+      let scalar = UnicodeScalar(byte)
       _ = menuBarModel.activate(matchingKey: Character(scalar))
       return
     }
@@ -128,7 +128,7 @@ public final class TerminalPresenter {
     guard awaitingAltChord else { return }
     awaitingAltChord = false
     guard let byte = data.first else { return }
-    guard let scalar = UnicodeScalar(byte) else { return }
+    let scalar = UnicodeScalar(byte)
     _ = menuBarModel.activate(matchingKey: Character(scalar))
   }
 }


### PR DESCRIPTION
## Summary
- conditionally depend on Trace, PosixInputStream, and SerialPort only for macOS builds
- add Linux-specific stubs and fallbacks so the module compiles without unavailable packages
- expose OutputController APIs needed by public protocols and clean up Unicode scalar handling
- actually managed to build and indeed, fix some errors, this makes the code ugly but now GPT can actually fix its shit
## Testing
- swift build


------
https://chatgpt.com/codex/tasks/task_e_68d8308266f08328a719f5ca137cb907