### PR TITLE
Handle truncated cursor position responses

### DIFF
--- a/Sources/SwiftTUI/TerminalInput.swift
+++ b/Sources/SwiftTUI/TerminalInput.swift
@@ -171,15 +171,16 @@ public struct TerminalInput {
   // a response (or future encapsulation type) should be considered an error
   
   func translate(_ sequence: ASNISequence) -> TerminalInput.Response? {
-    
+
     switch sequence.function {
 
       case "R" :
+        guard sequence.params.count >= 2 else { return nil }
         guard let row    = Int(sequence.params[0])  else { return nil } // NB this will crash if params
         guard let column = Int(sequence.params[1])  else { return nil } // aren't there. hmm.
-        
+
         return .CUROSR(row: row, column: column)
-      
+
       default : return nil
     }
   }

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -207,3 +207,21 @@ final class TerminalPresenterTests: XCTestCase {
         XCTAssertEqual(activations, ["File", "Edit"])
     }
 }
+
+final class TerminalInputTranslateTests: XCTestCase {
+
+    func testTranslateHandlesTruncatedCursorResponse() {
+        let input = TerminalInput()
+        var bytes = Data([0x1b])
+        bytes.append(contentsOf: "[12R".utf8)
+
+        let result = input.translate(bytes: bytes)
+
+        switch result {
+        case .failure:
+            break
+        case .success(let inputs):
+            XCTFail("Expected failure for truncated response, got \(inputs)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid subscripting cursor response parameters when the sequence is incomplete
- add a regression test that verifies truncated cursor position responses report failure

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d8471ee6ec832898018b3507a2096d