### PR TITLE
Handle printable ESC-prefixed sequences as character input

### DIFF
--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -208,6 +208,47 @@ final class TerminalPresenterTests: XCTestCase {
     }
 }
 
+final class TerminalInputPrintableSequenceTests: XCTestCase {
+
+    func testTranslateEscFollowedByLowercaseLetterProducesAsciiInput() {
+        let terminalInput = TerminalInput()
+        let result = terminalInput.translate(bytes: Data([0x1B, 0x66]))
+
+        switch result {
+        case .success(let inputs):
+            XCTAssertEqual(inputs.count, 1)
+
+            guard case let .ascii(data) = inputs.first else {
+                return XCTFail("Expected ascii input for ESC+f sequence")
+            }
+
+            XCTAssertEqual(data, Data([0x66]))
+
+        case .failure(let trace):
+            XCTFail("Unexpected failure for ESC+f sequence: \(trace)")
+        }
+    }
+
+    func testTranslateEscFollowedByUppercaseLetterProducesAsciiInput() {
+        let terminalInput = TerminalInput()
+        let result = terminalInput.translate(bytes: Data([0x1B, 0x41]))
+
+        switch result {
+        case .success(let inputs):
+            XCTAssertEqual(inputs.count, 1)
+
+            guard case let .ascii(data) = inputs.first else {
+                return XCTFail("Expected ascii input for ESC+A sequence")
+            }
+
+            XCTAssertEqual(data, Data([0x41]))
+
+        case .failure(let trace):
+            XCTFail("Unexpected failure for ESC+A sequence: \(trace)")
+        }
+    }
+}
+
 final class TerminalInputTranslateTests: XCTestCase {
 
     func testTranslateHandlesTruncatedCursorResponse() {


### PR DESCRIPTION
## Summary
- treat ESC-prefixed printable sequences without a '[' prefix as character input instead of signalling failure
- add regression coverage for translating ESC+letter combinations into ascii events

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d84e454cec8328972410cbb5f835db