### PR TITLE
Defer PosixInputStream resume until handler is installed

### DIFF
--- a/Sources/SwiftTUI/LightweightTestApp.swift
+++ b/Sources/SwiftTUI/LightweightTestApp.swift
@@ -82,6 +82,8 @@ public final class LightweightTestApp {
       }
     }
 
+    inputController?.stream.resume()
+
     inputController?.makeRaw()
   }
 

--- a/Sources/SwiftTUI/LinuxSupport.swift
+++ b/Sources/SwiftTUI/LinuxSupport.swift
@@ -23,5 +23,7 @@ public final class PosixInputStream {
   public init(descriptor: Int32) {
     _ = descriptor
   }
+
+  public func resume() {}
 }
 #endif


### PR DESCRIPTION
## Summary
- stop resuming the `PosixInputStream` inside `TerminalInputController`'s initializer
- resume the stream from `LightweightTestApp.start()` after installing the input handler so callbacks are ready

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d8588554f483288439ef829cd19d69