### PR TITLE
Use send for terminal control sequences in LightweightTestApp

### DIFF
--- a/Sources/SwiftTUI/LightweightTestApp.swift
+++ b/Sources/SwiftTUI/LightweightTestApp.swift
@@ -60,7 +60,7 @@ public final class LightweightTestApp {
     guard !running else { return }
     running = true
 
-    output.display(
+    output.send(
       .altBuffer,
       .clearScrollBack,
       .cls,
@@ -98,7 +98,7 @@ public final class LightweightTestApp {
 
     inputController?.unmakeRaw()
 
-    output.display(
+    output.send(
       .showCursor,
       .normBuffer
     )

--- a/Sources/SwiftTUI/TerminalPresenter.swift
+++ b/Sources/SwiftTUI/TerminalPresenter.swift
@@ -1,7 +1,18 @@
 import Foundation
 
+/// Abstraction used by ``TerminalPresenter`` so unit tests can provide mocks
+/// rather than writing directly to ``stdout``. Conforming types should proxy to
+/// ``OutputController``'s implementations so the presenter can either send
+/// sequences that query terminal state or display rendered UI elements.
 public protocol OutputDisplaying {
+  /// Display the provided sequences, updating the cursor position afterwards
+  /// to match ``OutputController/display(_:)-5k8a4``.
   func display(_ sequences: AnsiSequence...)
+
+  /// Send raw sequences without cursor tracking, mirroring
+  /// ``OutputController/send(_:)-5msk`` for cases where the presenter needs to
+  /// issue commands and inspect terminal responses.
+  func send(_ sequences: AnsiSequence...)
 }
 
 extension OutputController: OutputDisplaying {}
@@ -34,6 +45,8 @@ public final class TerminalPresenter {
 
   private var terminalWidth: Int
   private var terminalHeight: Int
+  // Keep protocol-based abstraction to allow tests to intercept output without
+  // writing to the real terminal.
   private let output: OutputDisplaying
   private let state: TerminalState
   private var statusBar: StatusBar

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -125,10 +125,15 @@ private final class MockOutputController: OutputDisplaying {
 
     var callCount = 0
     private(set) var lastSequences: [AnsiSequence] = []
+    private(set) var lastSentSequences: [AnsiSequence] = []
 
     func display(_ sequences: AnsiSequence...) {
         callCount += 1
         lastSequences = sequences
+    }
+
+    func send(_ sequences: AnsiSequence...) {
+        lastSentSequences = sequences
     }
 
     var lastRendered: String? {


### PR DESCRIPTION
## Summary
- send LightweightTestApp's terminal control sequences through `OutputDisplaying.send` so they bypass cursor tracking while preserving display for UI rendering

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d8611ec1408328aaced12064bbb8d7