### PR TITLE
Add status bar rendering and window size tracking

### DIFF
--- a/Sources/SwiftTUI/StatusBar.swift
+++ b/Sources/SwiftTUI/StatusBar.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public final class StatusBar {
+
+  public var foreground: ANSIForecolor
+  public var background: ANSIBackcolor
+
+  private let output: OutputController
+
+  public init(
+    output: OutputController = OutputController(),
+    foreground: ANSIForecolor = .black,
+    background: ANSIBackcolor = .bgWhite
+  ) {
+    self.output = output
+    self.foreground = foreground
+    self.background = background
+  }
+
+  public func draw(text: String, in size: winsize) {
+    let row = Int(size.ws_row)
+    let columns = Int(size.ws_col)
+    guard row > 0 && columns > 0 else { return }
+
+    let visibleText = String(text.prefix(columns))
+    let paddingCount = max(0, columns - visibleText.count)
+    let paddedText = visibleText + String(repeating: " ", count: paddingCount)
+
+    output.display(
+      .moveCursor(row: row, col: 1),
+      .backcolor(background),
+      .forecolor(foreground),
+      .text(paddedText),
+      .resetcolor
+    )
+  }
+}

--- a/Sources/SwiftTUI/Tracking.swift
+++ b/Sources/SwiftTUI/Tracking.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public final class WindowSizeTracking {
+
+  private let windowChanges: WindowChanges
+  private let statusBar: StatusBar
+
+  public init(
+    windowChanges: WindowChanges = WindowChanges(),
+    output: OutputController = OutputController(),
+    foreground: ANSIForecolor = .black,
+    background: ANSIBackcolor = .bgWhite
+  ) {
+    self.windowChanges = windowChanges
+    self.statusBar = StatusBar(
+      output: output,
+      foreground: foreground,
+      background: background
+    )
+
+    self.windowChanges.onChange = { [weak self] size in
+      self?.renderStatus(for: size)
+    }
+  }
+
+  public func start() {
+    renderStatus(for: windowChanges.size)
+    windowChanges.track()
+  }
+
+  public func stop() {
+    windowChanges.untrack()
+  }
+
+  private func renderStatus(for size: winsize) {
+    let columns = Int(size.ws_col)
+    let rows = Int(size.ws_row)
+    let text = "Window size: \(columns) x \(rows)"
+    statusBar.draw(text: text, in: size)
+  }
+
+  deinit {
+    windowChanges.untrack()
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `StatusBar` helper that renders a single-line bar at the bottom of the terminal with configurable colors
- introduce `WindowSizeTracking` to update the menubar with the current window dimensions whenever the window is resized

## Testing
- swift test *(fails on Linux because ioctl expects an argument of type UInt)*

------
https://chatgpt.com/codex/tasks/task_e_68dad721c9988328989c7cfa428eae24