### PR TITLE
Handle malformed ANSI responses while translating input

### DIFF
--- a/Sources/SwiftTUI/TerminalInput.swift
+++ b/Sources/SwiftTUI/TerminalInput.swift
@@ -302,17 +302,21 @@ public struct TerminalInput {
             // do, so we bail.
               
             case "[" :
-              
+
               if let cursor   = translate(sequence) {
                 inputs += [ .cursor(cursor) ]
                 break
               }
-              
-              if let response = translate( decompose(sequence) ) { inputs += [.response(response)] }
-              else                                               { fallthrough                     }
-            
+
+              if let response = translate( decompose(sequence) ) {
+                inputs += [ .response(response) ]
+                break
+              }
+
+              return .failure(Trace(self, tag: "unhandled control sequence \(errordesc(bytes))"))
+
             default :
-              
+
               guard let data = sequence.data(using: .utf8) else {
                 return .failure(Trace(self, tag: "unhandled non utf8 sequence \(errordesc(bytes))"))
               }

--- a/Sources/SwiftTUI/WindowChanges.swift
+++ b/Sources/SwiftTUI/WindowChanges.swift
@@ -21,13 +21,13 @@ public class WindowChanges {
     self.source = DispatchSource.makeSignalSource(signal: SIGWINCH, queue: queue)
     
     // get initial window frame
-    if ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) != 0 {
+    if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &size) != 0 {
       log("IOCTL fail, could not dermine initial windows size")
     }
     
     source.setEventHandler { [self] in
       var newsize = winsize()
-      if ioctl(STDOUT_FILENO, TIOCGWINSZ, &newsize) == 0 {
+      if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &newsize) == 0 {
         size = newsize
         onChange?(newsize)
       }


### PR DESCRIPTION
## Summary
- return a failure when bracketed escape sequences cannot be parsed so malformed responses are rejected
- cast the TIOCGWINSZ constant to UInt when invoking ioctl to keep Linux test builds working

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68db03f5991c8328bb5b50671cc51b1f