### PR TITLE
Guard ioctl request type for Linux

### DIFF
--- a/Sources/SwiftTUI/WindowChanges.swift
+++ b/Sources/SwiftTUI/WindowChanges.swift
@@ -5,44 +5,54 @@
 
 import Foundation
 
+#if os(Linux)
+private func ioctlWindowSize(_ winsizePointer: UnsafeMutablePointer<winsize>) -> Int32 {
+  ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), winsizePointer)
+}
+#else
+private func ioctlWindowSize(_ winsizePointer: UnsafeMutablePointer<winsize>) -> Int32 {
+  ioctl(STDOUT_FILENO, TIOCGWINSZ, winsizePointer)
+}
+#endif
+
 public class WindowChanges {
-  
-  
+
+
   private let queue   : DispatchQueue
   private let source  : DispatchSourceSignal
-  
+
   public var size     = winsize()
   public var onChange : ( (winsize) -> Void )? = nil
-  
-  
+
+
   public init() {
-    
+
     self.queue  = DispatchQueue(label: "SIGWINCH")
     self.source = DispatchSource.makeSignalSource(signal: SIGWINCH, queue: queue)
-    
+
     // get initial window frame
-    if ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) != 0 {
+    if ioctlWindowSize(&size) != 0 {
       log("IOCTL fail, could not dermine initial windows size")
     }
-    
+
     source.setEventHandler { [self] in
       var newsize = winsize()
-      if ioctl(STDOUT_FILENO, TIOCGWINSZ, &newsize) == 0 {
+      if ioctlWindowSize(&newsize) == 0 {
         size = newsize
         onChange?(newsize)
       }
     }
-  
+
   }
-  
-  
+
+
   public func track() {
     source.resume()
   }
-  
-  
+
+
   public func untrack() {
     source.cancel()
   }
-  
+
 }


### PR DESCRIPTION
## Summary
- restore the original `WindowChanges` implementation and share it across platforms
- add a helper that casts the `ioctl` request to `UInt` on Linux so the build succeeds

## Testing
- `swift test` *(fails: TerminalInputTranslateTests.testTranslateHandlesTruncatedCursorResponse)*

------
https://chatgpt.com/codex/tasks/task_e_68db00106b3483289d6dc86fb2254781