### PR TITLE
Add renderable menu bar to terminal app

### DIFF
--- a/Sources/SwiftTUI/MenuBar.swift
+++ b/Sources/SwiftTUI/MenuBar.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+public final class MenuItem : Renderable {
+
+  public var name      : String
+  public var foreground: ANSIForecolor
+  public var background: ANSIBackcolor
+
+  private var originRow: Int
+  private var originCol: Int
+
+
+  public init (
+    name      : String,
+    foreground: ANSIForecolor = .black,
+    background: ANSIBackcolor = .bgWhite
+  ) {
+    self.name       = name
+    self.foreground = foreground
+    self.background = background
+    self.originRow  = 1
+    self.originCol  = 1
+  }
+
+
+  func setOrigin ( row: Int, col: Int ) {
+    originRow = row
+    originCol = col
+  }
+
+
+  public func width ( maxWidth: Int? = nil ) -> Int {
+    let baseWidth = name.count + 2
+    guard let maxWidth = maxWidth else { return baseWidth }
+    return min(baseWidth, max(0, maxWidth))
+  }
+
+
+  public func render ( in size: winsize ) -> [AnsiSequence]? {
+
+    let rows    = Int(size.ws_row)
+    let columns = Int(size.ws_col)
+
+    guard rows > 0 && columns > 0 else { return nil }
+    guard originRow >= 1 && originRow <= rows else { return nil }
+    guard originCol >= 1 && originCol <= columns else { return nil }
+
+    let available = columns - originCol + 1
+    guard available > 0 else { return nil }
+
+    var sequences: [AnsiSequence] = [
+      .moveCursor(row: originRow, col: originCol),
+      .backcolor ( background ),
+      .forecolor ( foreground )
+    ]
+
+    var remaining = available
+
+    if remaining > 0 {
+      sequences.append(.text(" "))
+      remaining -= 1
+    }
+
+    if remaining > 0 && !name.isEmpty {
+      let firstChar = String(name.prefix(1))
+      sequences.append(.text("\u{001B}[1m\(firstChar)\u{001B}[22m"))
+      remaining -= 1
+
+      if remaining > 0 {
+        let rest = String(name.dropFirst().prefix(remaining))
+        if !rest.isEmpty {
+          sequences.append(.text(rest))
+          remaining -= rest.count
+        }
+      }
+    }
+
+    if remaining > 0 {
+      let trailingSpaceCount = min(1, remaining)
+      sequences.append(.text(String(repeating: " ", count: trailingSpaceCount)))
+      remaining -= trailingSpaceCount
+    }
+
+    sequences.append(.resetcolor)
+
+    return sequences
+  }
+}
+
+
+public final class MenuBar : Renderable {
+
+  public var items     : [MenuItem]
+  public var foreground: ANSIForecolor
+  public var background: ANSIBackcolor
+
+
+  public init (
+    items     : [MenuItem],
+    foreground: ANSIForecolor = .black,
+    background: ANSIBackcolor = .bgWhite
+  ) {
+    self.items      = items
+    self.foreground = foreground
+    self.background = background
+  }
+
+
+  public func render ( in size: winsize ) -> [AnsiSequence]? {
+
+    let rows    = Int(size.ws_row)
+    let columns = Int(size.ws_col)
+
+    guard rows > 0 && columns > 0 else { return nil }
+
+    var sequences: [AnsiSequence] = [
+      .moveCursor(row: 1, col: 1),
+      .backcolor ( background ),
+      .forecolor ( foreground ),
+      .repeatChars(" ", count: columns),
+      .resetcolor
+    ]
+
+    var currentColumn = 1
+
+    for item in items {
+      let available = columns - currentColumn + 1
+      guard available > 0 else { break }
+
+      item.setOrigin(row: 1, col: currentColumn)
+
+      if let itemSequences = item.render(in: size) {
+        sequences += itemSequences
+      }
+
+      currentColumn += item.width(maxWidth: available)
+    }
+
+    return sequences
+  }
+}

--- a/Sources/SwiftTUI/TerminalApp.swift
+++ b/Sources/SwiftTUI/TerminalApp.swift
@@ -16,6 +16,7 @@ public final class TerminalApp {
   
   private let window    : WindowChanges
   private let statusBar : StatusBar
+  private let menuBar   : MenuBar
   private let output    : OutputController
   private let input     : TerminalInputController
   private var cursor    : Cursor
@@ -31,6 +32,13 @@ public final class TerminalApp {
     self.output    = output
     self.input     = input
     self.statusBar = StatusBar( text: "", output: output )
+    self.menuBar   = MenuBar(
+      items: [
+        MenuItem(name: "Foo"),
+        MenuItem(name: "Bar"),
+        MenuItem(name: "Baz"),
+      ]
+    )
     
     // hook the window change handler, if the window size changes, we need to redraw
     // basically everything
@@ -92,7 +100,7 @@ public final class TerminalApp {
       )
       
       output.render (
-        elements: [ updateStatusBar (for: window.size) ],
+        elements: [ menuBar, updateStatusBar (for: window.size) ],
         in      : window.size
       )
     


### PR DESCRIPTION
## Summary
- add MenuItem and MenuBar renderables that draw a top-row menu with ANSI styling and bold accelerators
- render the new menu bar in `TerminalApp` with default Foo, Bar, and Baz items

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68db0678dc5083289b9680e46465b548