### PR TITLE
Use ANSI bold sequence in MenuBar

### DIFF
--- a/Sources/SwiftTUI/MenuBar.swift
+++ b/Sources/SwiftTUI/MenuBar.swift
@@ -73,7 +73,7 @@ public final class MenuItem : Renderable {
 
     if remaining > 0 && !name.isEmpty {
       let firstChar = String(name.prefix(1))
-      sequences.append(.text("\u{001B}[1m\(firstChar)\u{001B}[22m"))
+      sequences.append(.bold(firstChar))
       remaining -= 1
 
       if remaining > 0 {


### PR DESCRIPTION
## Summary
- replace the hard-coded bold escape sequence in `MenuBar` with the `AnsiSequence.bold` helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db38b5a680832891044e41fe037b9a