### PR TITLE
Expand MenuItem render comments

### DIFF
--- a/Sources/SwiftTUI/MenuBar.swift
+++ b/Sources/SwiftTUI/MenuBar.swift
@@ -51,13 +51,21 @@ public final class MenuItem : Renderable {
     let rows    = Int(size.ws_row)
     let columns = Int(size.ws_col)
 
+    // Validate the terminal dimensions before emitting any bytes. Rendering
+    // outside the reported window would at best waste work and at worst leave
+    // the cursor in an unexpected position for the caller.
     guard rows > 0 && columns > 0 else { return nil }
     guard originRow >= 1 && originRow <= rows else { return nil }
     guard originCol >= 1 && originCol <= columns else { return nil }
 
     let available = columns - originCol + 1
+    // If the menu origin is beyond the last visible column there is nothing to
+    // paint; return early so we do not emit color resets or other stray bytes.
     guard available > 0 else { return nil }
 
+    // Build the sequence list beginning with cursor placement and the color
+    // attributes that define this item's visual style. These must precede any
+    // text so the glyphs inherit the intended foreground/background pairing.
     var sequences: [AnsiSequence] = [
       .moveCursor(row: originRow, col: originCol),
       .backcolor ( background ),
@@ -66,6 +74,8 @@ public final class MenuItem : Renderable {
 
     var remaining = available
 
+    // Insert a leading space when possible. This gives each menu entry a
+    // consistent gutter so adjacent labels do not touch one another.
     if remaining > 0 {
       sequences.append(.text(" "))
       remaining -= 1
@@ -73,12 +83,17 @@ public final class MenuItem : Renderable {
 
     if remaining > 0 && !name.isEmpty {
       let firstChar = String(name.prefix(1))
+      // Emit the first character in bold to signal the keyboard accelerator.
+      // The highlight allows users to see which key activates this menu item.
       sequences.append(.bold(firstChar))
       remaining -= 1
 
       if remaining > 0 {
         let rest = String(name.dropFirst().prefix(remaining))
         if !rest.isEmpty {
+          // Append the remaining portion of the label that fits within the
+          // allocated width. Truncation is handled implicitly by prefixing with
+          // the number of columns still available.
           sequences.append(.text(rest))
           remaining -= rest.count
         }
@@ -87,10 +102,15 @@ public final class MenuItem : Renderable {
 
     if remaining > 0 {
       let trailingSpaceCount = min(1, remaining)
+      // Pad with a trailing space when there is still room. This ensures the
+      // background color extends through the cell immediately following the
+      // label, producing a solid block under the menu entry.
       sequences.append(.text(String(repeating: " ", count: trailingSpaceCount)))
       remaining -= trailingSpaceCount
     }
 
+    // Restore the caller's color configuration so subsequent drawing routines
+    // are not forced to undo our styling choices.
     sequences.append(.resetcolor)
 
     return sequences


### PR DESCRIPTION
## Summary
- expand the inline documentation in `MenuItem.render` to describe the rendering guards and styling steps in more detail

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db3a602c2083288f84e964b4c6b7f1