### PR TITLE
Add menu enhancement roadmap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,15 @@
+# TODO
+
+## Menu Enhancement Roadmap
+
+### Immediate Next Step
+1. Establish the runtime services that `MenuAction` needs so actions can do more than log text.
+   * Introduce an `OverlayManager` protocol and a basic overlay type (for example, a message box) that conforms to the existing `Renderable` pipeline.
+   * Expand `MenuActionContext` beyond `AppContext` so actions can request overlay presentation and issue output updates without owning terminal objects themselves.
+   * Update `TerminalApp` to assemble the context on demand—right before dispatching an action—so every invocation observes the latest window size, overlay stack, and output controller state.
+
+### Follow-Up Tasks
+* Flesh out `MenuAction` factories (e.g. `.message(_:)`, `.noop`, `.openURL(_:)`) using the richer context so simple menus can be wired without bespoke closures.
+* Allow accelerators to be configured independently of the item title so duplicate starting letters remain accessible.
+* Design a documentation payload (`MenuActionDocumentation`) and surface it through menu items to enable contextual help panes once overlays exist.
+* Consider serialization or inspection hooks for the menu hierarchy so external tools can introspect available commands.


### PR DESCRIPTION
## Summary
- add a TODO roadmap that captures the next implementation steps for the menu enhancement plan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc7260d4083288550a2278ef36198