### PR TITLE
Fix overlay box background fill

### DIFF
--- a/Sources/SwiftTUI/Box.swift
+++ b/Sources/SwiftTUI/Box.swift
@@ -69,7 +69,10 @@ public struct Box : Renderable {
           .backcolor (background),
           .forecolor (foreground),
           .box   (.vert),
+          .resetcolor,
           .repeatChars(" ", count: extent.width - 2),
+          .backcolor (background),
+          .forecolor (foreground),
           .box   (.vert),
           .resetcolor,
         ]


### PR DESCRIPTION
## Summary
- prevent overlay boxes from painting their interior background by resetting colors between borders

## Testing
- swift test (fails: no such module 'GLibc')

------
https://chatgpt.com/codex/tasks/task_e_68dbd18bde9c8328ad6dc9bbb11bfbf4