### PR TITLE
Set default box background to black

### DIFF
--- a/Sources/SwiftTUI/Box.swift
+++ b/Sources/SwiftTUI/Box.swift
@@ -26,7 +26,7 @@ public struct Box : Renderable {
     width     : Int,
     height    : Int,
     foreground: ANSIForecolor = .white,
-    background: ANSIBackcolor = .bgBlue
+    background: ANSIBackcolor = .bgBlack
   ) {
     position   = TermCoord(row: row, col: col)
     extent     = TermSize(width: width, height: height)

--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -62,7 +62,7 @@ public struct MenuAction {
     }
   }
 
-  public static func box ( row: Int, col: Int, width: Int, height: Int, foreground: ANSIForecolor = .white, background: ANSIBackcolor = .bgBlue ) -> MenuAction {
+  public static func box ( row: Int, col: Int, width: Int, height: Int, foreground: ANSIForecolor = .white, background: ANSIBackcolor = .bgBlack ) -> MenuAction {
     MenuAction { context, _ in
         context.overlays.drawBox(
           row       : row,

--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -16,7 +16,7 @@ public final class OverlayManager {
     width: Int,
     height: Int,
     foreground: ANSIForecolor = .white,
-    background: ANSIBackcolor = .bgBlue
+    background: ANSIBackcolor = .bgBlack
   ) {
     guard width >= 2 else { return }
     guard height >= 2 else { return }


### PR DESCRIPTION
## Summary
- update Box, OverlayManager, and MenuActions defaults to use the black background color

## Testing
- `swift test` *(fails: no such module 'GLibc')*

------
https://chatgpt.com/codex/tasks/task_e_68dbd3691ea48328a10dd840db204a09