### PR TITLE
Hide cursor after rendering overlays

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+private struct CursorHiddenBox: Renderable {
+  let box: Box
+
+  func render(in size: winsize) -> [AnsiSequence]? {
+    guard var sequences = box.render(in: size) else { return nil }
+    sequences.append(.hideCursor)
+    return sequences
+  }
+}
+
 public final class OverlayManager {
 
   private var overlays: [Renderable]
@@ -30,7 +40,7 @@ public final class OverlayManager {
       background: background
     )
 
-    overlays.append(box)
+    overlays.append(CursorHiddenBox(box: box))
     onChange?()
   }
 


### PR DESCRIPTION
## Summary
- wrap overlay boxes in a renderable that appends the hide-cursor sequence
- ensure the cursor remains hidden after overlay manager draws a box

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dbd572b8508328877cc320eb38dcf0