### PR TITLE
Inline BoxElement style access

### DIFF
--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -62,16 +62,17 @@ public struct MenuAction {
     }
   }
 
-  public static func box ( row: Int, col: Int, width: Int, height: Int, foreground: ANSIForecolor = .white, background: ANSIBackcolor = .bgBlack ) -> MenuAction {
+  public static func box (
+    row   : Int,
+    col   : Int,
+    width : Int,
+    height: Int,
+    style : ElementStyle = ElementStyle()
+  ) -> MenuAction {
     MenuAction { context, _ in
-        context.overlays.drawBox(
-          row       : row,
-          col       : col,
-          width     : width,
-          height    : height,
-          foreground: foreground,
-          background: background
-        )
+      let bounds = BoxBounds(row: row, col: col, width: width, height: height)
+      let element = BoxElement(bounds: bounds, style: style)
+      context.overlays.drawBox(element)
     }
   }
 

--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -11,20 +11,16 @@ public final class OverlayManager {
     self.overlays = overlays
   }
 
-  
-  public func drawBox ( row: Int, col: Int, width: Int, height: Int, foreground: ANSIForecolor = .white, background: ANSIBackcolor = .bgBlack ) {
-   
-    guard width >= 2 else { return }
-    guard height >= 2 else { return }
 
-    let box = Box(
-      row       : row,
-      col       : col,
-      width     : width,
-      height    : height,
-      foreground: foreground,
-      background: background
-    )
+  public func drawBox ( _ element: BoxElement ) {
+
+    let bounds = element.bounds
+
+    guard bounds.width  >= 2 else { return }
+    guard bounds.height >= 2 else { return }
+
+    // Persist the descriptor so overlay redraws can recover the full bounds and style.
+    let box = Box(element: element)
 
     overlays.append ( box )
     onChange?()


### PR DESCRIPTION
## Summary
- remove the redundant local style copy in `Box.render` and read colors from the element descriptor directly
- build `MessageBox` border and text styling from the assembled `BoxElement` without a separate style variable

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dbf1f0858c8328a1bbda846c5935d1