### PR TITLE
Add message box overlay action

### DIFF
--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -69,8 +69,15 @@ public struct MenuAction {
   }
   
   public static func messageBox ( _ message: String ) -> MenuAction {
-    MenuAction { context, item in
-      
+    MenuAction { context, _ in
+      // Push a transient message overlay so the calling menu item can surface feedback.
+      context.overlays.drawMessageBox(
+        message,
+        style: ElementStyle(
+          foreground: .white,
+          background: .black
+        )
+      )
     }
   }
 

--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -26,6 +26,26 @@ public final class OverlayManager {
     onChange?()
   }
 
+
+  public func drawMessageBox (
+    _ message: String,
+    row      : Int?          = nil,
+    col      : Int?          = nil,
+    style    : ElementStyle  = ElementStyle()
+  ) {
+
+    // Default to the provided style while letting the render pass pick final bounds.
+    let messageBox = MessageBox(
+      message: message,
+      row    : row,
+      col    : col,
+      style  : style
+    )
+
+    overlays.append ( messageBox )
+    onChange?()
+  }
+
   
   
   public func activeOverlays() -> [Renderable] {


### PR DESCRIPTION
## Summary
- add an OverlayManager helper to push message box renderables with optional placement and styling
- wire the MenuAction.messageBox factory to present overlays using the overlay manager

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dc09e8a5408328990c6c4b107d01e1