### PR TITLE
Add dismissible message box button overlay

### DIFF
--- a/Sources/SwiftTUI/Button.swift
+++ b/Sources/SwiftTUI/Button.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// Interactive overlays need a small protocol so they can tap keystrokes that
+// the application loop collects.  The button implements this so the overlay
+// manager can wire it up to TerminalApp without tightly coupling the types.
+protocol OverlayInputHandling: AnyObject {
+  func handle(_ input: TerminalInput.Input) -> Bool
+}
+
+/// Minimal button rendering that keeps the look consistent with the rest of the
+/// text UI.  The button draws a bracketed label centred within the supplied
+/// bounds and calls through to a handler when its activation key arrives.
+public final class Button: Renderable, OverlayInputHandling {
+
+  public var bounds      : BoxBounds
+  public let text        : String
+  public let style       : ElementStyle
+  public let activationKey: TerminalInput.ControlKey
+
+  private var onActivate : (() -> Void)?
+  private var isArmed    : Bool
+
+  public init(
+    bounds      : BoxBounds,
+    text        : String,
+    style       : ElementStyle = ElementStyle(),
+    activationKey: TerminalInput.ControlKey = .RETURN,
+    onActivate  : (() -> Void)? = nil
+  ) {
+    self.bounds        = bounds
+    self.text          = text
+    self.style         = style
+    self.activationKey = activationKey
+    self.onActivate    = onActivate
+    self.isArmed       = true
+
+    // Ensure we have at least enough width for the label plus brackets.
+    let minimum = max(minimumWidth, bounds.width)
+    if minimum != bounds.width {
+      self.bounds = BoxBounds(
+        row   : bounds.row,
+        col   : bounds.col,
+        width : minimum,
+        height: bounds.height
+      )
+    }
+  }
+
+  public var minimumWidth: Int { displayText.count }
+
+  private var displayText: String {
+    "[ \(text) ]"
+  }
+
+  public func render(in size: winsize) -> [AnsiSequence]? {
+
+    let rows    = Int(size.ws_row)
+    let columns = Int(size.ws_col)
+
+    guard rows > 0 && columns > 0 else { return nil }
+
+    let top    = bounds.row
+    let left   = bounds.col
+    let bottom = top  + max(bounds.height, 1) - 1
+    let right  = left + bounds.width        - 1
+
+    guard top    >= 1 else { return nil }
+    guard left   >= 1 else { return nil }
+    guard bottom <= rows else { return nil }
+    guard right  <= columns else { return nil }
+
+    // Only render within the first row of the supplied bounds for now.
+    guard bounds.height >= 1 else { return nil }
+    guard bounds.width  >= minimumWidth else { return nil }
+
+    let excessWidth   = bounds.width - minimumWidth
+    let leftPadding   = excessWidth / 2
+    let rightPadding  = excessWidth - leftPadding
+    let paddedContent = String(repeating: " ", count: leftPadding)
+                      + displayText
+                      + String(repeating: " ", count: rightPadding)
+
+    return [
+      .moveCursor(row: bounds.row, col: bounds.col),
+      .backcolor (style.background),
+      .forecolor (style.foreground),
+      .text      (paddedContent),
+      .resetcolor
+    ]
+  }
+
+  @discardableResult
+  public func handle(_ input: TerminalInput.Input) -> Bool {
+
+    guard isArmed else { return false }
+
+    switch input {
+
+      case .key(let key) where key == activationKey:
+        activate()
+        return true
+
+      case .ascii(let data) where activationKey == .RETURN:
+        if data.contains(0x0d) { // Carriage return
+          activate()
+          return true
+        }
+        return false
+
+      default:
+        return false
+    }
+  }
+
+  private func activate() {
+    guard isArmed else { return }
+    isArmed = false
+    onActivate?()
+  }
+}

--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -68,9 +68,17 @@ public struct MenuAction {
     }
   }
   
-  public static func messageBox ( _ message: String ) -> MenuAction {
+  public static func messageBox (
+    _ message: String,
+    buttonText: String = "OK",
+    activationKey: TerminalInput.ControlKey = .RETURN
+  ) -> MenuAction {
     MenuAction { context, _ in
-      context.overlays.drawMessageBox( message )
+      context.overlays.drawMessageBox(
+        message,
+        buttonText   : buttonText,
+        activationKey: activationKey
+      )
     }
   }
 

--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -4,11 +4,13 @@ import Foundation
 public final class OverlayManager {
 
   private var overlays: [Renderable]
+  private var interactiveOverlays: [OverlayInputHandling]
 
   public var onChange: (() -> Void)? = nil
 
   public init(overlays: [Renderable] = []) {
-    self.overlays = overlays
+    self.overlays            = overlays
+    self.interactiveOverlays = []
   }
 
 
@@ -27,28 +29,120 @@ public final class OverlayManager {
   }
 
 
-  public func drawMessageBox (_ message: String, row: Int? = nil, col: Int? = nil, style: ElementStyle  = ElementStyle() ) {
+  public func drawMessageBox (
+    _ message: String,
+    row      : Int?              = nil,
+    col      : Int?              = nil,
+    style    : ElementStyle      = ElementStyle(),
+    buttonText: String           = "OK",
+    activationKey: TerminalInput.ControlKey = .RETURN
+  ) {
 
-    // Default to the provided style while letting the render pass pick final bounds.
-    let messageBox = MessageBox(
-      message: message,
-      row    : row,
-      col    : col,
-      style  : style
+    let overlay = MessageBoxOverlay(
+      message      : message,
+      row          : row,
+      col          : col,
+      style        : style,
+      buttonText   : buttonText,
+      activationKey: activationKey,
+      onDismiss    : { [weak self] in self?.clear() }
     )
 
-    overlays.append ( messageBox )
+    overlays.append ( overlay )
+    interactiveOverlays.append( overlay )
     onChange?()
   }
 
-  
-  
+
+
   public func activeOverlays() -> [Renderable] {
     overlays
   }
 
+  public func handle(inputs: [TerminalInput.Input]) -> Bool {
+
+    guard !interactiveOverlays.isEmpty else { return false }
+
+    for input in inputs {
+      let handlers = interactiveOverlays
+      for overlay in handlers {
+        if overlay.handle(input) {
+          return true
+        }
+      }
+    }
+
+    return false
+  }
+
   public func clear() {
     overlays.removeAll()
+    interactiveOverlays.removeAll()
     onChange?()
+  }
+}
+
+
+private final class MessageBoxOverlay: Renderable, OverlayInputHandling {
+
+  private let messageBox: MessageBox
+  private let button    : Button
+
+  init(
+    message      : String,
+    row          : Int?,
+    col          : Int?,
+    style        : ElementStyle,
+    buttonText   : String,
+    activationKey: TerminalInput.ControlKey,
+    onDismiss    : @escaping () -> Void
+  ) {
+
+    var body = message
+    if !body.hasSuffix("\n") {
+      body += "\n"
+    }
+    body += "\n"
+
+    self.messageBox = MessageBox(message: body, row: row, col: col, style: style)
+    self.button     = Button(
+      bounds      : BoxBounds(row: row ?? 1, col: col ?? 1, width: buttonText.count + 4, height: 1),
+      text        : buttonText,
+      style       : style,
+      activationKey: activationKey,
+      onActivate  : onDismiss
+    )
+  }
+
+  func render(in size: winsize) -> [AnsiSequence]? {
+
+    guard let layout = messageBox.layout(in: size) else { return nil }
+    guard var sequences = messageBox.render(in: size) else { return nil }
+
+    let bounds         = layout.bounds
+    let interiorWidth  = bounds.width - 2
+    guard button.minimumWidth <= interiorWidth else { return sequences }
+
+    let labelWidth     = max(button.minimumWidth, 1)
+    let textStartRow   = bounds.row + 1
+    let buttonRow      = textStartRow + max(layout.lines.count - 1, 0)
+    let buttonCol      = bounds.col + 1 + max(0, (interiorWidth - labelWidth) / 2)
+
+    button.bounds = BoxBounds(
+      row   : buttonRow,
+      col   : buttonCol,
+      width : labelWidth,
+      height: 1
+    )
+
+    if let buttonSequences = button.render(in: size) {
+      sequences += buttonSequences
+    }
+
+    return sequences
+  }
+
+  func handle(_ input: TerminalInput.Input) -> Bool {
+    return button.handle(input)
   }
 }

--- a/Sources/SwiftTUI/TerminalApp.swift
+++ b/Sources/SwiftTUI/TerminalApp.swift
@@ -75,10 +75,16 @@ public final class TerminalApp {
   
   // process stdin
   func process (_ inputs: [TerminalInput.Input] ) {
-    
+
+    defer { awaitingMenuSelection = false }
+
+    if context.overlays.handle(inputs: inputs) {
+      return
+    }
+
     // Catch option-key menu shortcuts (sent as ESC-prefixed characters) and
     // trigger the corresponding menu item action.
-    
+
     for input in inputs {
       switch input {
 
@@ -91,7 +97,6 @@ public final class TerminalApp {
       }
     }
 
-    awaitingMenuSelection = false
   }
   
   // we probably nned to track the cursor position don't we?


### PR DESCRIPTION
## Summary
- add a renderable Button type that centres its label and reacts to activation keys
- extend the overlay manager to host dismissible message boxes with a button overlay
- route keystrokes from the app loop through overlays so buttons can close message boxes

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dc123772108328b84921670d00fc32