### PR TITLE
Propagate overlay clear hint

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -6,7 +6,7 @@ public final class OverlayManager {
   private var overlays: [Renderable]
   private var interactiveOverlays: [OverlayInputHandling]
 
-  public var onChange: (() -> Void)? = nil
+  public var onChange: ((Bool) -> Void)? = nil
 
   public init(overlays: [Renderable] = []) {
     self.overlays            = overlays
@@ -25,7 +25,7 @@ public final class OverlayManager {
     let box = Box(element: element)
 
     overlays.append ( box )
-    onChange?()
+    onChange?(false)
   }
 
 
@@ -53,12 +53,12 @@ public final class OverlayManager {
       style    : style,
       buttons  : buttonConfigs,
       onDismiss: { [weak self] in self?.clear() },
-      onUpdate : { [weak self] in self?.onChange?() }
+      onUpdate : { [weak self] in self?.onChange?(false) }
     )
 
     overlays.append ( overlay )
     interactiveOverlays.append( overlay )
-    onChange?()
+    onChange?(false)
   }
 
 
@@ -86,7 +86,7 @@ public final class OverlayManager {
   public func clear() {
     overlays.removeAll()
     interactiveOverlays.removeAll()
-    onChange?()
+    onChange?(true)
   }
 }
 

--- a/Sources/SwiftTUI/TerminalApp.swift
+++ b/Sources/SwiftTUI/TerminalApp.swift
@@ -36,8 +36,8 @@ public final class TerminalApp {
     
     
     // TODO: this is sematically unpleaseant and in the wrong place, we need a new strategy for change tracking and rendering, these probably belong in Renderer
-    self.context.overlays.onChange = { [weak self] in
-      self?.render(clearing: true)
+    self.context.overlays.onChange = { [weak self] shouldClear in
+      self?.render(clearing: shouldClear)
     }
     
     


### PR DESCRIPTION
## Summary
- add a clear-before-draw flag to OverlayManager change notifications and propagate it through overlay updates
- update TerminalApp to respect the flag when scheduling renders

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de7516d25483289dfc043ad927bfc4