### PR TITLE
Improve overlay input batching and add regression test

### DIFF
--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -217,4 +217,33 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
             )
         }
     }
+
+    func testMessageBoxAdvancesHighlightForBatchedCursorInputs() {
+        let manager = OverlayManager()
+        let buttons = [
+            MessageBoxButton(text: "Left"),
+            MessageBoxButton(text: "Middle"),
+            MessageBoxButton(text: "Right")
+        ]
+
+        manager.drawMessageBox(
+          "Cursor Walk",
+          row         : 1,
+          col         : 1,
+          style       : ElementStyle(),
+          buttonText  : "OK",
+          activationKey: .RETURN,
+          buttons     : buttons
+        )
+
+        guard let overlay = manager.activeOverlays().last as? MessageBoxOverlay else {
+            return XCTFail("Expected message box overlay")
+        }
+
+        // Batch cursor events to reproduce the regression that skipped later inputs.
+        let handled = manager.handle(inputs: [.cursor(.right), .cursor(.right)])
+
+        XCTAssertTrue(handled, "Expected overlay to handle cursor input batch")
+        XCTAssertEqual(overlay.debugActiveButtonIndex, 2, "Highlight should advance for each cursor event")
+    }
 }


### PR DESCRIPTION
## Summary
- buffer overlay inputs so batches are processed fully while preserving overflow for later passes
- expose the active button index for testing and add a regression test that covers batched cursor navigation

## Testing
- swift --version
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de782fc044832890f492659c5c29d3