### PR TITLE
Force message box overlays to redraw after clears

### DIFF
--- a/Sources/SwiftTUI/Button.swift
+++ b/Sources/SwiftTUI/Button.swift
@@ -8,6 +8,14 @@ protocol OverlayInputHandling: AnyObject {
   func handle(_ input: TerminalInput.Input) -> Bool
 }
 
+// Overlays that maintain internal caches need a hook so the manager can force a
+// full redraw when the terminal clears the screen.  The manager only calls this
+// when a repaint is unavoidable (window resize, manual clear, etc.) so the
+// overlay can flush any cached geometry before it renders again.
+protocol OverlayInvalidating: AnyObject {
+  func invalidateForFullRedraw()
+}
+
 /// Minimal button rendering that keeps the look consistent with the rest of the
 /// text UI.  The button draws a bracketed label centred within the supplied
 /// bounds and calls through to a handler when its activation key arrives.

--- a/Sources/SwiftTUI/TerminalApp.swift
+++ b/Sources/SwiftTUI/TerminalApp.swift
@@ -129,6 +129,9 @@ public final class TerminalApp {
     if clearing {
       context.output.send ( .cls )
       renderBaseElements(in: window.size)
+      // Clearing the display invalidates overlay caches so trigger a full
+      // redraw before asking them to render again.
+      context.overlays.invalidateActiveOverlays()
     }
 
     renderOverlayElements(in: window.size)


### PR DESCRIPTION
## Summary
- add an overlay invalidation protocol and let the manager drive full redraws when necessary
- reset MessageBoxOverlay caches when invalidated or when a layout fails so the dialog can recover cleanly
- have TerminalApp invalidate overlays before drawing after a clear so message boxes repaint correctly

## Testing
- not run (Swift 6.1 toolchain available in container, repository requests Swift 5)


------
https://chatgpt.com/codex/tasks/task_e_68de81c283b08328b8386a4732cc5d8f