### PR TITLE
Remove MenuActionContext in favor of AppContext

### DIFF
--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -34,32 +34,22 @@ public struct AppContext {
 }
 
 
-public struct MenuActionContext {
-
-  public var app      : AppContext
-  public var overlays : OverlayManager { app.overlays }
-
-  public init (app: AppContext ) {
-    self.app = app
-  }
-}
-
-public typealias MenuActionExecution = (MenuActionContext, MenuItem) -> Void
+public typealias MenuActionExecution = (AppContext, MenuItem) -> Void
 
 
 public struct MenuAction {
   
   public var execute : MenuActionExecution
-  
+
   public static func logMessage ( _ body: String ) -> MenuAction {
     MenuAction { context, item in
-      context.app.log("\(item.name): \(body)")
+      context.log("\(item.name): \(body)")
     }
   }
 
   public static func box (_ element: BoxElement ) -> MenuAction {
     MenuAction { context, item in
-      context.overlays.drawBox ( element ) 
+      context.overlays.drawBox ( element )
     }
   }
   

--- a/Sources/SwiftTUI/MenuBar.swift
+++ b/Sources/SwiftTUI/MenuBar.swift
@@ -2,17 +2,17 @@ import Foundation
 
 public final class MenuItem : Renderable {
 
-  public var name   : String
-  public var style  : ElementStyle
-  public var action : MenuAction
-  public var context: MenuActionContext
+  public var name    : String
+  public var style   : ElementStyle
+  public var action  : MenuAction
+  public var context : AppContext
   
   private var originRow: Int
   private var originCol: Int
   
   
 
-  public init ( name: String, style: ElementStyle, context: MenuActionContext, action: MenuAction ) {
+  public init ( name: String, style: ElementStyle, context: AppContext, action: MenuAction ) {
     self.name       = name
     self.context    = context
     self.action     = action

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 ### Immediate Next Step
 1. Establish the runtime services that `MenuAction` needs so actions can do more than log text.
    * Introduce an `OverlayManager` protocol and a basic overlay type (for example, a message box) that conforms to the existing `Renderable` pipeline.
-   * Expand `MenuActionContext` beyond `AppContext` so actions can request overlay presentation and issue output updates without owning terminal objects themselves.
+   * Expand `AppContext` so actions can request overlay presentation and issue output updates without owning terminal objects themselves.
    * Update `TerminalApp` to assemble the context on demand—right before dispatching an action—so every invocation observes the latest window size, overlay stack, and output controller state.
 
 ### Follow-Up Tasks


### PR DESCRIPTION
## Summary
- remove the MenuActionContext wrapper and pass AppContext directly to menu actions
- update menu items to retain AppContext instances and align property formatting
- refresh TODO notes to reference the consolidated context

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68de915147c48328b9d3cf37c612522d