### PR TITLE
Propagate app context to overlay handlers

### DIFF
--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -57,16 +57,20 @@ public struct MenuAction {
     MenuAction { context, _ in
       context.overlays.drawMessageBox(
         message,
+        context      : context,
         buttonText   : buttonText,
         activationKey: activationKey,
         buttons      : buttons
       )
     }
   }
-  
+
   public static func selectionList ( items: [SelectionListItem] ) -> MenuAction {
     MenuAction { context, _ in
-      context.overlays.drawSelectionList(items)
+      context.overlays.drawSelectionList(
+        items,
+        context: context
+      )
     }
   }
 

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -171,6 +171,7 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
     func testMessageBoxButtonsRenderWhenSpacingCollapses() {
         let manager = OverlayManager()
+        let context = AppContext(overlays: manager)
         let buttons = [
             MessageBoxButton(text: "YOK"),
             MessageBoxButton(text: "NOK"),
@@ -179,12 +180,13 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
         manager.drawMessageBox(
           "Tight\nDialog",
+          context     : context,
           row         : 2,
           col         : 2,
           style       : ElementStyle(),
           buttonText  : "OK",
           activationKey: .RETURN,
-          buttons     : buttons
+          buttons      : buttons
         )
 
         guard let overlay = manager.activeOverlays().last else {
@@ -220,6 +222,7 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
     func testMessageBoxAdvancesHighlightForBatchedCursorInputs() {
         let manager = OverlayManager()
+        let context = AppContext(overlays: manager)
         let buttons = [
             MessageBoxButton(text: "Left"),
             MessageBoxButton(text: "Middle"),
@@ -228,6 +231,7 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
         manager.drawMessageBox(
           "Cursor Walk",
+          context     : context,
           row         : 1,
           col         : 1,
           style       : ElementStyle(),
@@ -249,9 +253,11 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
     func testMessageBoxRedrawsButtonsOnlyWhenHighlightChanges() {
         let manager = OverlayManager()
+        let context = AppContext(overlays: manager)
 
         manager.drawMessageBox(
           "Smooth",
+          context     : context,
           row         : 1,
           col         : 1,
           style       : ElementStyle(),
@@ -311,12 +317,14 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
     func testSelectionListRendersItemsWithHighlight () {
         let manager = OverlayManager()
+        let context = AppContext(overlays: manager)
 
         manager.drawSelectionList (
           [
             SelectionListItem ( text: "One" ),
             SelectionListItem ( text: "Two" )
           ],
+          context  : context,
           row      : 2,
           col      : 2,
           style    : ElementStyle ( foreground: .white, background: .black ),
@@ -353,12 +361,14 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
     }
 
     func testSelectionListMovesHighlightWithArrowKeys () {
+        let context = AppContext()
         let overlay = SelectionListOverlay (
             items    : [
                 SelectionListItem ( text: "First" ),
                 SelectionListItem ( text: "Second" ),
                 SelectionListItem ( text: "Third" )
             ],
+            context  : context,
             row      : 1,
             col      : 1,
             style    : ElementStyle(),
@@ -379,8 +389,10 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
 
     func testSelectionListDismissesOnEscape () {
         var dismissCount = 0
+        let context = AppContext()
         let overlay = SelectionListOverlay (
             items    : [SelectionListItem ( text: "Only" )],
+            context  : context,
             row      : 1,
             col      : 1,
             style    : ElementStyle(),


### PR DESCRIPTION
## Summary
- require message box and selection list handlers to accept the AppContext and forward it from the overlay manager
- update overlay implementations to store the context for activation callbacks, with tests adjusted to pass the context through
- teach menu actions and overlays to wire the context into selection list item and message box button handlers

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de93da203c8328a893cbec8ee923b6