### PR TITLE
Add right-side padding to selection list overlay

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -754,7 +754,10 @@ final class SelectionListOverlay: Renderable, OverlayInputHandling, OverlayInval
 
   private static func minimumInteriorWidth ( for items: [SelectionListItem] ) -> Int {
     let widest = items.map { $0.text.count }.max() ?? 0
-    return max(widest + 1, 1)
+    // Provide a trailing space so highlighted rows never touch the right border.
+    // This matches the visual balance of the left padding and keeps the cursor
+    // well clear of the frame when the overlay is repainted.
+    return max(widest + 2, 2)
   }
 
   private static func highlightPalette ( for style: ElementStyle ) -> (foreground: ANSIForecolor, background: ANSIBackcolor) {

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -355,7 +355,7 @@ final class MessageBoxOverlayRenderingTests: XCTestCase {
             return nil
         }
 
-        [" One", " Two"].forEach { label in
+        [" One ", " Two "].forEach { label in
             XCTAssertTrue(rowStrings.contains ( label ), "Expected rendered row for \(label)")
         }
     }


### PR DESCRIPTION
## Summary
- add an extra column of interior padding so selection list rows leave space from the right border
- update selection list rendering expectations to include the new trailing space

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68de988fb27c83288c4c6e4d92a0f89a