### PR TITLE
Align message box divider with frame edge

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -377,9 +377,14 @@ final class MessageBoxOverlay: Renderable, OverlayInputHandling, OverlayInvalida
       let ruleRow   = buttonRow - 1
       let ruleStyle = messageBox.element.style
 
+      let ruleStartCol = bounds.col + 1
+
+      // Align the divider with the message box interior so the footer sits flush with
+      // the frame; keeping the buttons centred preserves their existing placement while
+      // avoiding a ragged left edge.
       sequences += [
         .hideCursor,
-        .moveCursor ( row: ruleRow, col: startCol ),
+        .moveCursor ( row: ruleRow, col: ruleStartCol ),
         .backcolor  ( ruleStyle.background ),
         .forecolor  ( ruleStyle.foreground ),
         .box        ( .horiz(interiorWidth) )


### PR DESCRIPTION
## Summary
- align the message box footer divider with the left interior edge of the frame to avoid ragged alignment
- keep button centring intact while ensuring the horizontal rule matches the surrounding box

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68deb1efc2588328b762f61564fe501e