### PR TITLE
Allow message boxes to close with Escape

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -193,6 +193,7 @@ final class MessageBoxOverlay: Renderable, OverlayInputHandling, OverlayInvalida
 
   private let messageBox  : MessageBox
   private let context     : AppContext
+  private let onDismiss   : () -> Void
   private var buttons     : [Button]
   private var activeIndex : Int
   private let onUpdate    : (() -> Void)?
@@ -258,6 +259,7 @@ final class MessageBoxOverlay: Renderable, OverlayInputHandling, OverlayInvalida
       minimumInteriorWidth: minimumInteriorWidth
     )
     self.context     = context
+    self.onDismiss   = onDismiss
     self.activeIndex = 0
     self.onUpdate    = onUpdate
     self.cachedLayout = nil
@@ -459,6 +461,14 @@ final class MessageBoxOverlay: Renderable, OverlayInputHandling, OverlayInvalida
         }
 
         return activeIndex != previousIndex
+
+      case .key(let key):
+        if key == .ESC {
+          // Mirror the selection list overlay so ESC consistently dismisses modal chrome.
+          onDismiss()
+          return true
+        }
+        return buttons[activeIndex].handle(input)
 
       default:
         return buttons[activeIndex].handle(input)


### PR DESCRIPTION
## Summary
- store the dismiss handler on `MessageBoxOverlay` so it can be reused
- dismiss message boxes when ESC is pressed while keeping other key handling intact

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68debd16a68883289329a348b46d53be