### PR TITLE
Target overlay dismissal clears

### DIFF
--- a/Sources/SwiftTUI/Box.swift
+++ b/Sources/SwiftTUI/Box.swift
@@ -42,7 +42,7 @@ public struct BoxElement {
 }
 
 
-public struct Box : Renderable {
+public struct Box : Renderable, OverlayBoundsReporting {
 
   let element: BoxElement
 
@@ -50,6 +50,10 @@ public struct Box : Renderable {
     // Keep the higher level BoxElement descriptor intact so downstream
     // renderers can inspect both bounds and styling directly.
     self.element = element
+  }
+
+  public var overlayBounds: BoxBounds? {
+    element.bounds
   }
 
   public func render ( in terminalSize: winsize ) -> [AnsiSequence]? {

--- a/Sources/SwiftTUI/TerminalApp.swift
+++ b/Sources/SwiftTUI/TerminalApp.swift
@@ -129,13 +129,17 @@ public final class TerminalApp {
     let overlayElements  = context.overlays.activeOverlays()
     let invalidation     : (() -> Void)? = (clearMode == .full) ? { [context] in context.overlays.invalidateActiveOverlays() } : nil
 
+    // Capture the cleared overlay bounds so the renderer can target its scrub pass.
+    let overlayClearBounds = (clearMode == .overlayDismissal) ? context.overlays.consumeClearedOverlayBounds() : []
+
     context.output.renderFrame (
-      base        : baseElements,
-      overlay     : overlayElements,
-      in          : size,
-      defaultStyle: defaultStyle,
-      clearMode   : clearMode,
-      onFullClear : invalidation
+      base              : baseElements,
+      overlay           : overlayElements,
+      in                : size,
+      defaultStyle      : defaultStyle,
+      clearMode         : clearMode,
+      onFullClear       : invalidation,
+      overlayClearBounds: overlayClearBounds
     )
 
   }


### PR DESCRIPTION
## Summary
- add an overlay bounds reporting protocol so dismissed overlays can expose their last geometry
- retain the cleared overlay bounds and feed them into Renderer so only the affected rows are scrubbed
- expand the renderer tests to cover targeted clears and adjust the fallback clear expectation

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68dffec21cf8832892779d80a407df22