### PR TITLE
Enforce strict overlay focus for interactive overlays

### DIFF
--- a/Sources/SwiftTUI/Renderer.swift
+++ b/Sources/SwiftTUI/Renderer.swift
@@ -154,16 +154,22 @@ public class Renderer {
         let height  = Int ( size.ws_row ) - 2
 
         if columns > 0 && height > 0 {
-          clear ( rectangle:
-            BoxBounds (
-              row    : 2,
-              col    : 1,
-              width  : columns,
-              height : height
-            )
-          )
+          var sequences: [AnsiSequence] = [ .saveCursor ]
+
+          for offset in 0..<height {
+            let row = 2 + offset
+            // Use the terminal's native clear so dismissal cannot leave artifacts in
+            // rows that previously held overlay content.
+            sequences += [
+              .moveCursor(row: row, col: 1),
+              .killLine
+            ]
+          }
+
+          sequences.append ( .restoreCursor )
+          render ( sequences )
         }
-      
+
       }
     
     }


### PR DESCRIPTION
## Summary
- ensure overlay input handling only forwards events to the top-most interactive overlay and swallows unhandled keys
- clear blanket overlay dismissal rows with kill line sequences so modal teardown cannot leave artifacts
- add lightweight AppContext test shims and a regression test covering overlay input swallowing

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e01714646c8328957cfd6c5181f19f