### PR TITLE
Prevent OverlayManager from removing buffered inputs past bounds

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -180,7 +180,14 @@ public final class OverlayManager {
     }
 
     if processedCount > 0 {
-      bufferedInputs.removeFirst(processedCount)
+      // Clearing an overlay during dispatch can empty the buffer via the guard
+      // above. Guard the removal so we never walk past the shrunken array while
+      // draining events delivered to an overlay that dismissed itself.
+      if bufferedInputs.count >= processedCount {
+        bufferedInputs.removeFirst(processedCount)
+      } else {
+        bufferedInputs.removeAll()
+      }
     }
 
     return handledAny || sawInteractiveOverlay


### PR DESCRIPTION
## Summary
- guard buffered input trimming so overlay self-dismissals cannot overrun the buffer
- document the guard to clarify the crash scenario

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e01d4a93688328a03bfd232d392042