### PR TITLE
Add anchored menu selection list helper

### DIFF
--- a/Sources/SwiftTUI/MenuActions.swift
+++ b/Sources/SwiftTUI/MenuActions.swift
@@ -45,6 +45,29 @@ public struct MenuAction {
     }
   }
 
+  public static func anchoredSelectionList ( items: [SelectionListItem], rowOffset: Int = 1, colOffset: Int = 0, row: Int? = nil, col: Int? = nil ) -> MenuAction {
+    MenuAction { context, item in
+
+      // Derive overlay coordinates from the menu item's stored origin so the
+      // submenu appears adjacent to its trigger. Offsets keep the overlay a
+      // predictable distance away (defaulting to the row beneath the menu bar)
+      // and clamping guards against wandering into column or row zero.
+
+      let anchor      = item.anchor
+      let anchoredRow = max(1, anchor.row + rowOffset)
+      let anchoredCol = max(1, anchor.col + colOffset)
+
+      // Allow overriding coordinates explicitly so centred or bespoke layouts
+      // remain possible while the default anchored offsets stay predictable.
+      context.overlays.drawSelectionList(
+        items,
+        context: context,
+        row    : row ?? anchoredRow,
+        col    : col ?? anchoredCol
+      )
+    }
+  }
+
 }
 
 

--- a/Sources/SwiftTUI/MenuBar.swift
+++ b/Sources/SwiftTUI/MenuBar.swift
@@ -6,10 +6,18 @@ public final class MenuItem : Renderable {
   public var style   : ElementStyle
   public var action  : MenuAction
   public var context : AppContext
-  
+
   private var originRow: Int
   private var originCol: Int
-  
+
+  // Expose the anchor through a computed property so overlays can align
+  // themselves relative to the menu item while keeping the mutable state local
+  // to the item. The stored coordinates remain private to avoid external
+  // mutation while still allowing callers to reason about placement.
+  public var anchor : (row: Int, col: Int) {
+    (row: originRow, col: originCol)
+  }
+
   
 
   public init ( name: String, style: ElementStyle, context: AppContext, action: MenuAction ) {


### PR DESCRIPTION
## Summary
- restore `MenuAction.selectionList` to its centered default behaviour
- add `MenuAction.anchoredSelectionList` to position overlays relative to menu anchors with configurable offsets

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e022e85118832893d46cf07c3a7c34