### PR TITLE
Ensure renderer redraws base content after overlay dismissal

### DIFF
--- a/Sources/SwiftTUI/Renderer.swift
+++ b/Sources/SwiftTUI/Renderer.swift
@@ -124,15 +124,20 @@ public class Renderer {
     )
 
     
+    var hasRenderedBase = false
+
     func handleFullClear () {
-      
+
       // so annoyingly, it turns out that we can't actually just use cls for this as it just resets
       // the terminal's defaults. arse
       // send ( .cls )
-      
+
       clear ( rectangle: BoxBounds ( row: 1, col: 1, width: Int ( size.ws_col ), height: Int ( size.ws_row ) ) )
-      
+
       if !base.isEmpty {
+        // we track the base rendering so later logic knows not to double-draw the same elements
+        // during a full clear cycle. skipping the second render prevents pointless redraw work.
+        hasRenderedBase = true
         render (
           elements: base,
           in      : size
@@ -179,6 +184,15 @@ public class Renderer {
       case .none              : break
       case .full              : handleFullClear()
       case .overlayDismissal  : handleOverlayDismissal()
+    }
+
+    if !base.isEmpty && !hasRenderedBase {
+      // render the base when we did not go through the full clear path so overlays keep their
+      // expected stacking order.
+      render (
+        elements: base,
+        in      : size
+      )
     }
 
     if !overlay.isEmpty {

--- a/Tests/SwiftTUITests/SwiftTUITests.swift
+++ b/Tests/SwiftTUITests/SwiftTUITests.swift
@@ -489,8 +489,7 @@ final class RendererRenderFrameTests: XCTestCase {
         let renderer = Renderer()
         let size = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
 
-        let baseExpectation = expectation(description: "Base should not rerender on overlay clear")
-        baseExpectation.isInverted = true
+        let baseExpectation = expectation(description: "Base should rerender on overlay clear")
 
         let invalidationExpectation = expectation(description: "Overlay invalidation should not run for overlay-only clear")
         invalidationExpectation.isInverted = true


### PR DESCRIPTION
## Summary
- track whether `renderFrame` has already repainted the base during a full clear
- redraw base content for `.none` and `.overlayDismissal` frames so menu highlights persist
- update the overlay dismissal test to expect the base rerender

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e03b312fe48328bd6a07ddd376809e