### PR TITLE
Refine TUIElement usage across overlays

### DIFF
--- a/Sources/SwiftTUI/Button.swift
+++ b/Sources/SwiftTUI/Button.swift
@@ -74,24 +74,8 @@ public final class Button: Renderable, OverlayInputHandling {
   }
 
   let hex = HexDump()
-  public func render(in size: winsize) -> [AnsiSequence]? {
+  public func render ( in size: winsize ) -> [AnsiSequence]? {
 
-    let rows    = Int(size.ws_row)
-    let columns = Int(size.ws_col)
-
-    guard rows > 0 && columns > 0 else { return nil }
-
-    let top    = bounds.row
-    let left   = bounds.col
-    let bottom = top  + max(bounds.height, 1) - 1
-    let right  = left + bounds.width        - 1
-
-    guard top    >= 1 else { return nil }
-    guard left   >= 1 else { return nil }
-    guard bottom <= rows else { return nil }
-    guard right  <= columns else { return nil }
-
-    // Only render within the first row of the supplied bounds for now.
     guard bounds.height >= 1 else { return nil }
     guard bounds.width  >= minimumWidth else { return nil }
 
@@ -102,30 +86,24 @@ public final class Button: Renderable, OverlayInputHandling {
                       + displayText
                       + String(repeating: " ", count: rightPadding)
 
-    let baseBackground     = style.background
-    let baseForeground     = style.foreground
-    let highlightBack   = highlightBackground ?? baseBackground
-    let highlightFore   = highlightForeground ?? baseForeground
-    let shouldHighlight = isHighlightActive
+    let baseBackground    = style.background
+    let baseForeground    = style.foreground
+    let highlightBack     = highlightBackground ?? baseBackground
+    let highlightFore     = highlightForeground ?? baseForeground
+    let shouldHighlight   = isHighlightActive
 
     // The highlight palette keeps overlays visually coherent without forcing
     // every caller to understand ANSI attributes.  Previously inactive buttons
     // used SGR 2 dimming to hint at focus order, however that made text hard to
     // read on terminals with low contrast.  Instead we now leave them rendered
     // with their base palette so they are merely not highlighted.
-    let activeBackground = shouldHighlight ? highlightBack : baseBackground
-    let activeForeground = shouldHighlight ? highlightFore : baseForeground
+    let activeBackground  = shouldHighlight ? highlightBack : baseBackground
+    let activeForeground  = shouldHighlight ? highlightFore : baseForeground
+    let rowBounds         = BoxBounds ( row: bounds.row, col: bounds.col, width: bounds.width, height: 1 )
+    let rowStyle          = ElementStyle ( foreground: activeForeground, background: activeBackground )
+    let element           = TUIElement.textRow ( bounds: rowBounds, style: rowStyle, text: paddedContent, includeHideCursor: false )
 
-
-    let seqs : [AnsiSequence] =  [
-      .moveCursor(row: bounds.row, col: bounds.col),
-      .backcolor (activeBackground),
-      .forecolor (activeForeground),
-      .text(paddedContent),
-    ]
-
-    
-    return seqs
+    return element.render ( in: size )
   }
 
   @discardableResult

--- a/Sources/SwiftTUI/StatusBar.swift
+++ b/Sources/SwiftTUI/StatusBar.swift
@@ -13,22 +13,19 @@ public final class StatusBar : Renderable {
 
   
   public func render ( in size: winsize ) -> [AnsiSequence]? {
-    
+
     let row     = Int(size.ws_row)
     let columns = Int(size.ws_col)
-    
+
     guard row > 0 && columns > 0 else { return nil }
 
-    let visibleText  = String(text.prefix(columns))
-    let paddingCount = max(0, columns - visibleText.count)
-    let paddedText   = visibleText + String(repeating: " ", count: paddingCount)
+    let visibleText  = String ( text.prefix(columns) )
+    let paddingCount = max ( 0, columns - visibleText.count )
+    let paddedText   = visibleText + String ( repeating: " ", count: paddingCount )
+    let bounds       = BoxBounds ( row: row, col: 1, width: paddedText.count, height: 1 )
+    // The helper keeps palette and cursor handling consistent with other single-row widgets.
+    let element      = TUIElement.textRow ( bounds: bounds, style: style, text: paddedText )
 
-    return [
-      .hideCursor,
-      .moveCursor ( row: row, col: 1 ),
-      .backcolor  ( style.background ),
-      .forecolor  ( style.foreground ),
-      .text       ( paddedText ),
-    ]
+    return element.render ( in: size )
   }
 }

--- a/Sources/SwiftTUI/SwiftTUI.swift
+++ b/Sources/SwiftTUI/SwiftTUI.swift
@@ -17,12 +17,72 @@ public protocol Renderable {
 
 
 struct TUIElement : Renderable {
-  
+
   var sequences: [AnsiSequence]
   var bounds   : BoxBounds
-  
-  public func render(in size: winsize) -> [AnsiSequence]? {
-    sequences
+
+  init ( bounds: BoxBounds, sequences: [AnsiSequence] ) {
+    // Cache the prebuilt sequences so repeated renders avoid rebuilding the same
+    // ANSI payload.  Validation still happens per frame to keep bounds in sync
+    // with the active terminal size.
+    self.bounds    = bounds
+    self.sequences = sequences
   }
-  
+
+  static func textRow ( bounds: BoxBounds, style: ElementStyle, text: String, includeHideCursor: Bool = true ) -> TUIElement {
+
+    var sequences: [AnsiSequence] = []
+
+    if includeHideCursor { sequences.append(.hideCursor) }
+
+    sequences += [
+      .moveCursor ( row: bounds.row, col: bounds.col ),
+      .backcolor  ( style.background ),
+      .forecolor  ( style.foreground ),
+      .text       ( text ),
+    ]
+
+    return TUIElement ( bounds: bounds, sequences: sequences )
+  }
+
+  public func render ( in size: winsize ) -> [AnsiSequence]? {
+    guard TUIElement.bounds ( bounds, fitIn: size ) else { return nil }
+    return sequences
+  }
+
+  static func render ( _ elements: [TUIElement], in size: winsize ) -> [AnsiSequence]? {
+
+    var output: [AnsiSequence] = []
+
+    for element in elements {
+      guard let sequences = element.render ( in: size ) else { return nil }
+      output += sequences
+    }
+
+    return output
+  }
+
+  private static func bounds ( _ bounds: BoxBounds, fitIn size: winsize ) -> Bool {
+
+    let rows    = Int(size.ws_row)
+    let columns = Int(size.ws_col)
+
+    guard bounds.width  > 0 else { return false }
+    guard bounds.height > 0 else { return false }
+
+    guard rows    > 0 else { return false }
+    guard columns > 0 else { return false }
+
+    guard bounds.row >= 1 else { return false }
+    guard bounds.col >= 1 else { return false }
+
+    let bottom = bounds.row + bounds.height - 1
+    let right  = bounds.col + bounds.width  - 1
+
+    guard bottom <= rows else { return false }
+    guard right  <= columns else { return false }
+
+    return true
+  }
+
 }


### PR DESCRIPTION
## Summary
- add bounds validation and styled text helpers to `TUIElement`
- rebuild button, menu item, status bar, and message box output with the new helpers
- have overlay renderers aggregate `TUIElement` segments instead of raw ANSI arrays

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e04c1867d48328ba6877eccc729f54