### PR TITLE
Refactor overlay input handling around reusable key handler

### DIFF
--- a/Sources/SwiftTUI/Button.swift
+++ b/Sources/SwiftTUI/Button.swift
@@ -3,7 +3,14 @@ import Foundation
 // the application loop collects.  The button implements this so the overlay
 // manager can wire it up to TerminalApp without tightly coupling the types.
 protocol OverlayInputHandling: AnyObject {
+  var keyHandler: KeyHandler { get }
   func handle(_ input: TerminalInput.Input) -> Bool
+}
+
+extension OverlayInputHandling {
+  func handle ( _ input: TerminalInput.Input ) -> Bool {
+    keyHandler.handle ( input )
+  }
 }
 
 // Overlays that maintain internal caches need a hook so the manager can force a

--- a/Sources/SwiftTUI/KeyHandler.swift
+++ b/Sources/SwiftTUI/KeyHandler.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+// Centralise keyboard dispatch so overlays can share a small amount of stateful
+// behaviour such as ESC swallowing without duplicating switch statements.  The
+// handler keeps the registration API deliberately tiny so modal overlays can
+// wire the pieces they need and rely on the fallback for delegation.
+final class KeyHandler {
+
+  typealias ControlHandler  = () -> Bool
+  typealias CursorHandler   = () -> Bool
+  typealias PayloadHandler  = (Data) -> Bool
+  typealias ResponseHandler = (TerminalInput.Response) -> Bool
+
+  private var controlHandlers  : [TerminalInput.ControlKey: ControlHandler]
+  private var cursorHandlers   : [TerminalInput.CursorKey: CursorHandler]
+  private var asciiHandlers    : [PayloadHandler]
+  private var unicodeHandlers  : [PayloadHandler]
+  private var responseHandlers : [ResponseHandler]
+  private var fallbackHandler  : ((TerminalInput.Input) -> Bool)?
+  private var swallowPrintableAfterESC: Bool
+
+  init ( swallowPrintableAfterESC: Bool = false ) {
+    self.controlHandlers          = [:]
+    self.cursorHandlers           = [:]
+    self.asciiHandlers            = []
+    self.unicodeHandlers          = []
+    self.responseHandlers         = []
+    self.fallbackHandler          = nil
+    self.swallowPrintableAfterESC = swallowPrintableAfterESC
+  }
+
+  func registerControl ( _ key: TerminalInput.ControlKey, swallowPrintableAfterESC: Bool = false, handler: @escaping ControlHandler ) {
+    controlHandlers[key] = handler
+    if key == .ESC && swallowPrintableAfterESC {
+      self.swallowPrintableAfterESC = true
+    }
+  }
+
+  func registerCursor ( _ key: TerminalInput.CursorKey, handler: @escaping CursorHandler ) {
+    cursorHandlers[key] = handler
+  }
+
+  func registerASCII ( _ handler: @escaping PayloadHandler ) {
+    asciiHandlers.append(handler)
+  }
+
+  func registerUnicode ( _ handler: @escaping PayloadHandler ) {
+    unicodeHandlers.append(handler)
+  }
+
+  func registerResponse ( _ handler: @escaping ResponseHandler ) {
+    responseHandlers.append(handler)
+  }
+
+  func registerFallback ( _ handler: @escaping (TerminalInput.Input) -> Bool ) {
+    fallbackHandler = handler
+  }
+
+  func trapsControl ( _ key: TerminalInput.ControlKey ) -> Bool {
+    controlHandlers[key] != nil
+  }
+
+  var shouldSwallowPrintableAfterEscape: Bool {
+    trapsControl ( .ESC ) && swallowPrintableAfterESC
+  }
+
+  @discardableResult
+  func handle ( _ input: TerminalInput.Input ) -> Bool {
+    switch input {
+
+      case .key ( let key ) :
+        if let handler = controlHandlers[key] {
+          return handler()
+        }
+
+      case .cursor ( let key ) :
+        if let handler = cursorHandlers[key] {
+          return handler()
+        }
+
+      case .ascii ( let data ) :
+        for handler in asciiHandlers where handler(data) { return true }
+
+      case .unicode ( let data ) :
+        for handler in unicodeHandlers where handler(data) { return true }
+
+      case .response ( let response ) :
+        for handler in responseHandlers where handler(response) { return true }
+    }
+
+    return fallbackHandler?(input) ?? false
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `KeyHandler` helper to centralise control, cursor, payload, and response dispatch
- update modal overlays to configure dedicated key handlers and expose ESC swallowing so the manager can coordinate lookahead
- wire `TerminalApp` through the shared handler so menu chords and terminal responses are handled consistently

## Testing
- TERM=dumb swift test

------
https://chatgpt.com/codex/tasks/task_e_68e1584ee74083289db6ce9c986574fd