### PR TITLE
Implement streaming terminal input decoder

### DIFF
--- a/Sources/SwiftTUI/TerminalInput.swift
+++ b/Sources/SwiftTUI/TerminalInput.swift
@@ -1,5 +1,3 @@
-
-
 import Foundation
 #if canImport(Trace)
 import Trace
@@ -8,27 +6,27 @@ import Trace
 /*
   Handle the various things that the macOS (and this is NOT portable)
   terminal will stuff into the STDIN pipe in response to a whole bunch of stuff.
- 
+
   Basically it's all in band signalling, so that's where everything goes,
   especially with a term in raw mode there is very little to be done with signal
   handlers and such, so we need to catch a lot of, well, stuff.
- 
+
   I havent written a whole ANSI spec parser because life is too short
- 
+
   and stuff.
- 
+
 */
 
 
 public struct TerminalInput {
-  
+
 
   // ASCII <= 0x1f, and on the mac also DEL at 0x7f as well as arrow keys
   // all of these occur by the user pressing a key, some of them require
   // us to do stuff (move the cursor, translate a CR/LF sequence, backspace, etc
   // some of them we pass to remoter terminal equipment, either way, they are all
   // special and require us to make decisions, so they each have an enum. sigh.
-  
+
   public enum ControlKey : Hashable {
     case NULL
     case STX
@@ -64,24 +62,24 @@ public struct TerminalInput {
     case US
     case DEL         // sent by <- key on macOS (backspace vs del bunfight)
   }
-  
-  
+
+
   public enum CursorKey : Hashable {
     case left, right, up, down
   }
-  
-  
+
+
   // If the terminal is sending us escape sequences via stdin then it's (probably)
   // in response to something we asked it. This is likely to expand as we build
   // more features
-  
+
   public enum Response : Hashable {
     case CURSOR (row: Int, column: Int)  // for now just cursor position
   }
-  
-  
+
+
   // our eventual output will be an array of these
-  
+
   public enum Input : Hashable {
     case key     (TerminalInput.ControlKey)  // spesh key
     case cursor  (TerminalInput.CursorKey)   // cursor key
@@ -92,19 +90,19 @@ public struct TerminalInput {
   // ok, so we split ascii and unicode mainly because a) it probably isnt a great idea
   // to stuff unicode down a serial pipe and b) that's basically anky key ant ALT on
   // the mac and I want those for UI control, menus, etc. fight me.
-  
-  
+
+
   // intermediate struct for decoding escape sequences
-  
+
   struct ASNISequence {
     let function :  String
     let params   : [String]
   }
-  
-  
-  
+
+
+
   // O(1) map of ASCII codes to their symbolic enum
-  
+
   let ascii_table : [UInt8 : TerminalInput.ControlKey] = [
     0x00 : .NULL,
     0x01 : .STX,
@@ -140,36 +138,36 @@ public struct TerminalInput {
     0x1f : .US,
     0x7f : .DEL
   ]
-  
-  
+
+
   // O(1) map of arrow keys to their symbolic enum
-  
+
   let cursor_table : [String : TerminalInput.CursorKey] = [
     "[A" : .up,
     "[B" : .down,
     "[C" : .right,
     "[D" : .left
   ]
-  
+
   public init() {}
   // conversion funcs that retun nil if the input isnt one of the tables
-  
+
   func translate(_ u8: UInt8) -> TerminalInput.ControlKey? {
     ascii_table[u8]
   }
-  
-  
-  
+
+
+
   func translate(_ string: String) -> TerminalInput.CursorKey? {
     cursor_table[string]
   }
-  
-  
-  
+
+
+
   // Add any query responses you want to process here.
   // for now it's just the cursor keys. failure of a sequence to map to
   // a response (or future encapsulation type) should be considered an error
-  
+
   func translate(_ sequence: ASNISequence) -> TerminalInput.Response? {
 
     switch sequence.function {
@@ -184,162 +182,351 @@ public struct TerminalInput {
       default : return nil
     }
   }
-  
-  
+
+
   // ugly hacky way to extract params from an escape sequence formatted liek "[x;xA"
   // which accounts for many, though certainly not all, of the ones we expect xterm
   // to stuff in the pipe
-  
+
   func decompose( _ sequence: String) -> ASNISequence {
     ASNISequence (
       function: String(sequence.last!),
       params  : sequence.dropFirst().dropLast().components(separatedBy: ";")
     )
   }
-  
-  
-  // occasionally xterm will stuff multiple control seqs in the pipe, this splits
-  // them up and drops the ESC prefixes, leaving us with e,g, [ "[r;cR", ...]
 
-  func split(_ sequence: Data) -> [String]? {
-    String(data: sequence, encoding: .utf8)?
-        .dropFirst()
-        .components(separatedBy: "\u{1b}")
-  }
 
-  
   // robust error handling
-  
+
   func errordesc(_ bytes: Data) -> String {
     String(describing: String(data: bytes, encoding: .utf8))
   }
 
 
-  
-  // When we don't recognise the escape sequence as one of the structured
-  // control sequences above we fall back to treating it as a literal "meta"
-  // key press. macOS sends ESC-prefixed printable characters for Option-key
-  // combinations, so we split the escape off and treat the remainder as
-  // normal text.
-  
-  func processMeta ( sequence: String, data: Data ) -> [TerminalInput.Input] {
+  /*
+    Streaming decoder that keeps state between reads. The terminal will
+    frequently fragment escape sequences across multiple reads, so we keep
+    the current buffer and parser state around until we have the full
+    sequence. A simple state machine keeps us grounded when we only have
+    printable data while still allowing CSI / OSC responses and UTF8 scalars
+    to span chunks.
+  */
 
-    var inputs : [TerminalInput.Input] = []
+  struct Decoder {
 
-    // CharacterSet.controlCharacters matches ASCII control bytes (0x00-0x1f
-    // plus DEL). If the remainder contains any of those then it is likely part
-    // of an ANSI control sequence we don't understand, so we shouldn't treat it
-    // as plain text.
-    let containsControl = sequence.rangeOfCharacter(from: CharacterSet.controlCharacters) != nil
 
-    // The split above already removed the leading ESC. Any printable characters
-    // that remain are part of the meta-key payload and should be delivered
-    // alongside the ESC key. Checking for the general control-character set
-    // instead of just another ESC prevents us from mis-classifying multi-byte
-    // control sequences as regular text.
-    if !containsControl {
-      inputs += [ .key(.ESC) ]
+    enum TextContext {
+      case plain
+      case meta
+    }
+
+
+    enum OSCTerminator {
+      case bel
+      case st
+    }
+
+
+    struct OSCState {
+      let terminator : OSCTerminator
+      var sawEscape  : Bool
+    }
+
+
+    enum ParserState {
+      case ground
+      case escape
+      case csi
+      case osc (OSCState)
+      case utf8(TextContext, remaining: Int)
+    }
+
+
+    var input         : TerminalInput
+    var state         : ParserState
+    var escapeBuffer  : Data
+    var unicodeBuffer : Data
+    var textBuffer    : Data
+
+
+    init ( input: TerminalInput ) {
+      self.input         = input
+      self.state         = .ground
+      self.escapeBuffer  = Data()
+      self.unicodeBuffer = Data()
+      self.textBuffer    = Data()
+    }
+
+
+    mutating func feed ( _ chunk: Data ) -> Result<[TerminalInput.Input], Trace> {
+
+      var outputs : [TerminalInput.Input] = []
+
+      guard chunk.count > 0 else { return .success(outputs) }
+
+      for byte in chunk {
+
+        switch state {
+
+          case .ground :
+
+            if byte == 0x1b {
+              emitText(into: &outputs)
+              escapeBuffer = Data([byte])
+              state        = .escape
+              continue
+            }
+
+            if let key = input.translate(byte) {
+              emitText(into: &outputs)
+              outputs += [ .key(key) ]
+              continue
+            }
+
+            if byte < 0x80 {
+              textBuffer.append(byte)
+              continue
+            }
+
+            emitText(into: &outputs)
+
+            guard let remaining = continuationLength(for: byte) else {
+              return .failure(Trace(input, tag: "invalid utf8 lead byte \(input.errordesc(Data([byte])))"))
+            }
+
+            unicodeBuffer = Data([byte])
+            state         = .utf8(.plain, remaining: remaining)
+
+
+          case .escape :
+
+            escapeBuffer.append(byte)
+
+            switch byte {
+
+              case 0x5b :
+                state = .csi
+
+              case 0x5d :
+                state = .osc(OSCState(terminator: .bel, sawEscape: false))
+
+              case 0x50 :
+                state = .osc(OSCState(terminator: .st, sawEscape: false))
+
+              default :
+
+                if byte < 0x20 || byte == 0x7f {
+                  return .failure(Trace(input, tag: "unhandled control sequence \(input.errordesc(escapeBuffer))"))
+                }
+
+                if byte < 0x80 {
+                  outputs += [ .key(.ESC), .ascii(Data([byte])) ]
+                  escapeBuffer.removeAll()
+                  state = .ground
+                }
+                else {
+                  guard let remaining = continuationLength(for: byte) else {
+                    return .failure(Trace(input, tag: "invalid utf8 lead byte \(input.errordesc(escapeBuffer))"))
+                  }
+
+                  outputs += [ .key(.ESC) ]
+                  unicodeBuffer = Data([byte])
+                  state         = .utf8(.meta, remaining: remaining)
+                }
+            }
+
+
+          case .csi :
+
+            escapeBuffer.append(byte)
+
+            if isFinalCSI(byte) {
+              let payload = escapeBuffer.dropFirst()
+
+              guard let sequence = String(data: payload, encoding: .utf8) else {
+                return .failure(Trace(input, tag: "unhandled non utf8 sequence \(input.errordesc(escapeBuffer))"))
+              }
+
+              if let cursor = input.translate(sequence) {
+                outputs += [ .cursor(cursor) ]
+              }
+              else if let response = input.translate(input.decompose(sequence)) {
+                outputs += [ .response(response) ]
+              }
+              else {
+                return .failure(Trace(input, tag: "unhandled control sequence \(input.errordesc(escapeBuffer))"))
+              }
+
+              escapeBuffer.removeAll()
+              state = .ground
+            }
+
+
+          case .osc(var oscState) :
+
+            escapeBuffer.append(byte)
+
+            switch oscState.terminator {
+
+              case .bel :
+                if byte == 0x07 {
+                  return .failure(Trace(input, tag: "unhandled control sequence \(input.errordesc(escapeBuffer))"))
+                }
+
+              case .st :
+                if oscState.sawEscape {
+                  if byte == 0x5c {
+                    return .failure(Trace(input, tag: "unhandled control sequence \(input.errordesc(escapeBuffer))"))
+                  }
+                  else {
+                    oscState.sawEscape = false
+                  }
+                }
+                else if byte == 0x1b {
+                  oscState.sawEscape = true
+                }
+            }
+
+            state = .osc(oscState)
+
+
+          case .utf8(let context, var remaining) :
+
+            guard isContinuation(byte) else {
+              return .failure(Trace(input, tag: "invalid utf8 continuation byte \(input.errordesc(Data([byte])))"))
+            }
+
+            unicodeBuffer.append(byte)
+
+            if context == .meta {
+              escapeBuffer.append(byte)
+            }
+
+            remaining -= 1
+
+            if remaining == 0 {
+
+              switch context {
+
+                case .plain :
+                  outputs += [ .unicode(unicodeBuffer) ]
+
+                case .meta :
+                  outputs += [ .unicode(unicodeBuffer) ]
+              }
+
+              unicodeBuffer.removeAll()
+              escapeBuffer.removeAll()
+              state = .ground
+            }
+            else {
+              state = .utf8(context, remaining: remaining)
+            }
+        }
+      }
+
+      emitText(into: &outputs)
+
+      return .success(outputs)
+    }
+
+
+    mutating func emitText ( into outputs: inout [TerminalInput.Input] ) {
+
+      guard textBuffer.count > 0 else { return }
+
+      let data = textBuffer
+
+      textBuffer = Data()
 
       if data.count == 1, let first = data.first, first < 0x80 {
-        inputs += [ .ascii(data) ]
+        outputs += [ .ascii(data) ]
       }
       else {
-        // Hmmm
-        inputs += [ .unicode(data) ]
+        outputs += [ .unicode(data) ]
       }
-
-      
     }
-    
-    return inputs
+
+
+    mutating func flush() -> Result<[TerminalInput.Input], Trace> {
+
+      switch state {
+
+        case .ground :
+          var outputs : [TerminalInput.Input] = []
+          emitText(into: &outputs)
+          return .success(outputs)
+
+        case .escape :
+          return .failure(Trace(input, tag: "unterminated escape sequence \(input.errordesc(escapeBuffer))"))
+
+        case .csi :
+          return .failure(Trace(input, tag: "unterminated control sequence \(input.errordesc(escapeBuffer))"))
+
+        case .osc :
+          return .failure(Trace(input, tag: "unterminated control sequence \(input.errordesc(escapeBuffer))"))
+
+        case .utf8(let context, _) :
+          switch context {
+            case .plain :
+              return .failure(Trace(input, tag: "unterminated unicode scalar \(input.errordesc(unicodeBuffer))"))
+            case .meta  :
+              return .failure(Trace(input, tag: "unterminated meta sequence \(input.errordesc(escapeBuffer))"))
+          }
+      }
+    }
+
+
+    func isFinalCSI(_ byte: UInt8) -> Bool {
+      byte >= 0x40 && byte <= 0x7e
+    }
+
+
+    func continuationLength(for byte: UInt8) -> Int? {
+      switch byte {
+        case 0xc2 ... 0xdf : return 1
+        case 0xe0 ... 0xef : return 2
+        case 0xf0 ... 0xf4 : return 3
+        default            : return nil
+      }
+    }
+
+
+    func isContinuation(_ byte: UInt8) -> Bool {
+      (byte & 0xc0) == 0x80
+    }
   }
 
-  
-  
-  
+
   //MARK: Public API
-  
+
   // OK, here we go go.
   // take some bytes from STDIN and basically add contextual wrapping to them
   // we return either a Key, a Response or some ascii or unicode bytes
-  
-  
+
+
   public func translate(bytes: Data) -> Result<[TerminalInput.Input], Trace> {
-    
+
     guard bytes.count > 0 else { return .failure(Trace(self, tag: "zero byte count")) }
-    
-    // single byte is either an alphanum char or an ASCII control char,
-    // let's check out the control chars first
-    
-    if bytes.count == 1 {
-      if let key = translate( bytes[0] ) { return .success( [.key   (key)   ] ) }
-      else                               { return .success( [.ascii (bytes) ] ) }
-    }
-    
-    
-    // ok, we have a multibyte sequence, does it start with an ESC ?
-    // if so we'll do a split on it to try and catch any xterm spam we caused
-    
-    switch bytes[0] {
-    
-      case 0x1b :
-      
-        var inputs : [TerminalInput.Input] = []
-      
-        guard let sequences = split(bytes)
-        else {
-          return .failure(Trace(self, tag: "borked splitting sequences '\(errordesc(bytes))" ))
+
+    var decoder = Decoder(input: self)
+
+    switch decoder.feed(bytes) {
+
+      case .failure(let trace) :
+        return .failure(trace)
+
+      case .success(let outputs) :
+
+        switch decoder.flush() {
+
+          case .failure(let trace) :
+            return .failure(trace)
+
+          case .success(let trailing) :
+            return .success(outputs + trailing)
         }
-        
-        
-      
-        for sequence in sequences {
-          
-          switch sequence.prefix(1) {
-            
-            // right now we only care about regular control sequences,
-            // if we strt getting device (P) or OS (]) control sequences, we wont know what to
-            // do, so we bail.
-              
-            case "[" :
-
-              if let cursor   = translate(sequence) {
-                inputs += [ .cursor(cursor) ]
-                break
-              }
-
-              if let response = translate( decompose(sequence) ) {
-                inputs += [ .response(response) ]
-                break
-              }
-
-              return .failure(Trace(self, tag: "unhandled control sequence \(errordesc(bytes))"))
-
-            default :
-
-              guard let data = sequence.data(using: .utf8) else {
-                return .failure(Trace(self, tag: "unhandled non utf8 sequence \(errordesc(bytes))"))
-              }
-            
-              let meta = processMeta ( sequence: sequence, data: data )
-              if meta.isEmpty {
-                return .failure(Trace(self, tag: "unhandled control sequence \(errordesc(bytes))"))
-              }
-              else {
-                inputs += meta
-              }
-              
-          }
-        }
-      
-        return .success(inputs)
-      
-      // if we're here we have a multibyte sequence that isnt a control seq, so ...
-      default : return .success( [.unicode(bytes)] )
-          
     }
-    
   }
-  
-}
 
+}


### PR DESCRIPTION
## Summary
- introduce a stateful `TerminalInput.Decoder` that incrementally parses control keys, CSI/OSC sequences, meta chords, and UTF-8 scalars
- route `TerminalInput.translate` through the decoder to keep legacy API behaviour while supporting streaming input

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e1b08345fc8328a6719b54caba3a9e