### PR TITLE
Remove redundant selection list bytes handler

### DIFF
--- a/Sources/SwiftTUI/OverlayManager.swift
+++ b/Sources/SwiftTUI/OverlayManager.swift
@@ -1032,20 +1032,8 @@ final class SelectionListOverlay: Renderable, OverlayInputHandling, OverlayInval
       }
     ]
 
-    let bytesHandler: KeyHandler.BytesInputHandler = { [weak self] bytes in
-      guard let overlay = self else { return false }
-
-      switch bytes {
-        case .ascii   ( let data ),
-             .unicode ( let data ) :
-          guard data.contains ( 0x0d ) else { return false }
-          return overlay.activateSelection()
-      }
-    }
-
     keyHandler.pushHandler ( KeyHandler.HandlerTableEntry (
-      control : controlHandlers,
-      bytes   : bytesHandler
+      control : controlHandlers
     ) )
   }
 


### PR DESCRIPTION
## Summary
- stop the selection list overlay from registering a bytes handler
- rely on the existing control handler so RETURN continues to activate the current selection

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e1b78f6b2483289763e07114664943