### PR TITLE
Ensure TerminalApp stop restores terminal state

### DIFF
--- a/Sources/SwiftTUI/TerminalApp.swift
+++ b/Sources/SwiftTUI/TerminalApp.swift
@@ -219,10 +219,22 @@ public final class TerminalApp {
 
   
   public func stop() {
+    // The shutdown path mirrors the init sequence so raw input, hidden cursors
+    // and the alternate buffer are unwound in the reverse order before we drop
+    // the window tracking hooks and hand control back to the shell.
+    context.input.unmakeRaw()
+
+    context.output.send (
+      .resetFGBG,
+      .showCursor,
+      .normBuffer,
+      .moveCursor(row: 1, col: 1)
+    )
+
     window.untrack()
   }
-  
+
   deinit {
-    window.untrack()
+    stop()
   }
 }


### PR DESCRIPTION
## Summary
- restore cooked input and the primary buffer when stopping TerminalApp
- route deinitialisation through the stop routine so cleanup always runs
- document the symmetry between startup and teardown of terminal state

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e46a7909e08328922247cdd45c6408